### PR TITLE
ehci: update hardcode for hpmicro

### DIFF
--- a/port/ehci/usb_hc_ehci.c
+++ b/port/ehci/usb_hc_ehci.c
@@ -644,8 +644,8 @@ static int usbh_reset_port(const uint8_t port)
     uint32_t timeout = 0;
     uint32_t regval;
 
-#if CONFIG_USB_EHCI_HCOR_BASE == (0xF2020000UL + 0x140)
-    if ((*(volatile uint32_t *)(0xF2020000UL + 0x224) & 0xc0) == (2 << 6)) { /* Hardcode for hpm */
+#if defined(CONFIG_USB_EHCI_HPMICRO) && CONFIG_USB_EHCI_HPMICRO
+    if ((*(volatile uint32_t *)(CONFIG_HPM_USB_BASE + 0x224) & 0xc0) == (2 << 6)) { /* Hardcode for hpm */
         EHCI_HCOR->portsc[port - 1] |= (1 << 29);
     } else {
         EHCI_HCOR->portsc[port - 1] &= ~(1 << 29);


### PR DESCRIPTION
- should define CONFIG_USB_EHCI_HPMICRO and CONFIG_HPM_USB_BASE in usb_config.h