### PR TITLE
update for midi

### DIFF
--- a/class/audio/usb_audio.h
+++ b/class/audio/usb_audio.h
@@ -812,6 +812,19 @@ struct audio_cs_ep_ep_general_descriptor {
 
 #define AUDIO_AS_DESCRIPTOR_INIT_LEN(n) (0x09 + 0x09 + 0x07 + 0x08 + 3 * n + 0x09 + 0x07)
 
+#define AUDIO_MS_STANDARD_DESCRIPTOR_INIT(bInterfaceNumber, bNumEndpoints)                                               \
+    0x09,                            /* bLength */                                                                       \
+    USB_DESCRIPTOR_TYPE_INTERFACE,   /* bDescriptorType */                                                               \
+    bInterfaceNumber,                /* bInterfaceNumber */                                                              \
+    0x00,                            /* bAlternateSetting */                                                             \
+    bNumEndpoints,                   /* bNumEndpoints */                                                                 \
+    USB_DEVICE_CLASS_AUDIO,          /* bInterfaceClass */                                                               \
+    AUDIO_SUBCLASS_MIDISTREAMING,    /* bInterfaceSubClass */                                                            \
+    AUDIO_PROTOCOL_UNDEFINED,        /* bInterfaceProtocol */                                                            \
+    0x00                             /* iInterface */
+
+#define AUDIO_MS_STANDARD_DESCRIPTOR_INIT_LEN 0x09
+
 struct audio_v2_channel_cluster_descriptor {
     uint8_t bNrChannels;
     uint32_t bmChannelConfig;
@@ -1072,7 +1085,7 @@ struct audio_v2_control_range3_param_block {
     USB_DESCRIPTOR_TYPE_ENDPOINT,    /* bDescriptorType */                                                                                                                \
     bEndpointAddress,                /* bEndpointAddress 3 out endpoint for Audio */                                                                                      \
     bmAttributes,                    /* bmAttributes */                                                                                                                   \
-    WBVAL(wMaxPacketSize),           /* XXXX wMaxPacketSize in Bytes (SampleRate * SlotByteSize * NumChannels) */                                                               \
+    WBVAL(wMaxPacketSize),           /* XXXX wMaxPacketSize in Bytes (SampleRate * SlotByteSize * NumChannels) */                                                         \
     bInterval,                       /* bInterval */                                                                                                                      \
     0x08,                            /* bLength */                                                                                                                        \
     AUDIO_ENDPOINT_DESCRIPTOR_TYPE,  /* bDescriptorType */                                                                                                                \

--- a/class/midi/usb_midi.h
+++ b/class/midi/usb_midi.h
@@ -23,6 +23,26 @@
 #define MIDI_PITCHBEND_MIN -8192
 #define MIDI_PITCHBEND_MAX 8191
 
+/*! Enumeration of MIDI code index number */
+enum MidiCodeIndexNumber {
+    MIDI_CIN_MISC              = 0,
+    MIDI_CIN_CABLE_EVENT       = 1,
+    MIDI_CIN_SYSCOM_2BYTE      = 2, ///< 2 byte system common message e.g MTC, SongSelect
+    MIDI_CIN_SYSCOM_3BYTE      = 3, ///< 3 byte system common message e.g SPP
+    MIDI_CIN_SYSEX_START       = 4, ///< SysEx starts or continue
+    MIDI_CIN_SYSEX_END_1BYTE   = 5, ///< SysEx ends with 1 data, or 1 byte system common message
+    MIDI_CIN_SYSEX_END_2BYTE   = 6, ///< SysEx ends with 2 data
+    MIDI_CIN_SYSEX_END_3BYTE   = 7, ///< SysEx ends with 3 data
+    MIDI_CIN_NOTE_OFF          = 8,
+    MIDI_CIN_NOTE_ON           = 9,
+    MIDI_CIN_POLY_KEYPRESS     = 10,
+    MIDI_CIN_CONTROL_CHANGE    = 11,
+    MIDI_CIN_PROGRAM_CHANGE    = 12,
+    MIDI_CIN_CHANNEL_PRESSURE  = 13,
+    MIDI_CIN_PITCH_BEND_CHANGE = 14,
+    MIDI_CIN_1BYTE_DATA        = 15
+};
+
 /*! Enumeration of MIDI types */
 enum MidiType {
     InvalidType = 0x00,          ///< For notifying errors
@@ -181,6 +201,13 @@ struct midi_cs_ep_ms_general_descriptor {
 #define MIDI_SIZEOF_MS_GENERAL_DESC(n) (4 + n)
 
 // clang-format off
+#define MIDI_CS_HEADER_DESCRIPTOR_INIT(wTotalLength)                                              \
+    0x07,                                             /* bLength */                               \
+    USB_CS_DESCRIPTOR_TYPE_INTERFACE,                 /* bDescriptorType */                       \
+    MIDI_MS_HEADER_DESCRIPTOR_SUBTYPE,                /* bDescriptorSubtype */                    \
+    WBVAL(0x0100),                                    /* bcdMSC */                                \
+    WBVAL(wTotalLength)                               /* wTotalLength */
+
 #define MIDI_IN_JACK_DESCRIPTOR_INIT(bJackType, bJackID) \
     0x06,                                                \
     0x24,                                                \

--- a/class/wireless/usbh_rndis.c
+++ b/class/wireless/usbh_rndis.c
@@ -14,7 +14,7 @@ USB_NOCACHE_RAM_SECTION USB_MEM_ALIGNX uint8_t g_rndis_buf[4096];
 static struct usbh_rndis g_rndis_class[CONFIG_USBHOST_MAX_RNDIS_CLASS];
 static uint32_t g_devinuse = 0;
 
-static struct usbh_rndis *usbd_rndis_class_alloc(void)
+static struct usbh_rndis *usbh_rndis_class_alloc(void)
 {
     int devno;
 
@@ -29,7 +29,7 @@ static struct usbh_rndis *usbd_rndis_class_alloc(void)
     return NULL;
 }
 
-static void usbd_rndis_class_free(struct usbh_rndis *rndis_class)
+static void usbh_rndis_class_free(struct usbh_rndis *rndis_class)
 {
     int devno = rndis_class->minor;
 
@@ -270,7 +270,7 @@ static int usbh_rndis_connect(struct usbh_hubport *hport, uint8_t intf)
     uint8_t tmp_buffer[512];
     uint8_t data[32];
 
-    struct usbh_rndis *rndis_class = usbd_rndis_class_alloc();
+    struct usbh_rndis *rndis_class = usbh_rndis_class_alloc();
     if (rndis_class == NULL) {
         USB_LOG_ERR("Fail to alloc rndis_class\r\n");
         return -ENOMEM;
@@ -419,7 +419,7 @@ static int usbh_rndis_disconnect(struct usbh_hubport *hport, uint8_t intf)
             usbh_rndis_stop(rndis_class);
         }
 
-        usbd_rndis_class_free(rndis_class);
+        usbh_rndis_class_free(rndis_class);
     }
 
     return ret;

--- a/demo/midi_template.c
+++ b/demo/midi_template.c
@@ -9,7 +9,7 @@
 #define USBD_MAX_POWER     100
 #define USBD_LANGID_STRING 1033
 
-#define USB_CONFIG_SIZE (9 + 9 + 9 + 9 + 7 + MIDI_SIZEOF_JACK_DESC + 7 + 5 + 7 + 5)
+#define USB_CONFIG_SIZE (9 + 9 + 9 + 9 + 7 + MIDI_SIZEOF_JACK_DESC + 9 + 5 + 9 + 5)
 
 #ifdef CONFIG_USB_HS
 #define MIDI_EP_MPS 512
@@ -64,11 +64,11 @@ const uint8_t midi_descriptor[] = {
     // MIDI_OUT_JACK_DESCRIPTOR_INIT(MIDI_JACK_TYPE_EXTERNAL, 0x04, 0x01),
     MIDI_JACK_DESCRIPTOR_INIT(0x01),
     // OUT endpoint descriptor
-    USB_ENDPOINT_DESCRIPTOR_INIT(MIDI_OUT_EP, 0x02, MIDI_EP_MPS, 0x00),
+    0x09, 0x05, MIDI_OUT_EP, 0x02, WBVAL(MIDI_EP_MPS), 0x00, 0x00, 0x00,
     0x05, 0x25, 0x01, 0x01, 0x01,
 
     // IN endpoint descriptor
-    USB_ENDPOINT_DESCRIPTOR_INIT(MIDI_IN_EP, 0x02, MIDI_EP_MPS, 0x00),
+    0x09, 0x05, MIDI_IN_EP, 0x02, WBVAL(MIDI_EP_MPS), 0x00, 0x00, 0x00,
     0x05, 0x25, 0x01, 0x01, 0x03,
 
     ///////////////////////////////////////


### PR DESCRIPTION
- add MidiCodeIndexNumber enum
- update midi descriptor. Audio v1.0's endpoint has 9 bytes instead of 7.