### PR TITLE
[common] Avoid IAR compiling error on USB HOST stack

### DIFF
--- a/common/usb_hc.h
+++ b/common/usb_hc.h
@@ -59,7 +59,11 @@ struct usbh_urb {
     uint32_t start_frame;
     usbh_complete_callback_t complete;
     void *arg;
+#if defined(__ICCARM__) || defined(__ICCRISCV__) || defined(__ICCRX__)
+    struct usbh_iso_frame_packet *iso_packet;
+#else
     struct usbh_iso_frame_packet iso_packet[0];
+#endif
 };
 
 /**


### PR DESCRIPTION
- Avoided using a structure with zero-length array as a field in another structure when IAR toolchain is used.