### PR TITLE
AT32 gccfg adds the vbusig flag by default

### DIFF
--- a/port/dwc2/usb_glue_at.c
+++ b/port/dwc2/usb_glue_at.c
@@ -13,18 +13,35 @@
 uint32_t usbd_get_dwc2_gccfg_conf(void)
 {
 #ifdef CONFIG_USB_HS
-    return (1 << 16);
+    return ((1 << 16) | (1 << 21));
 #else
-    // return ((1 << 16) | (1 << 18) | (1 << 19));
-    return (1 << 16);
+    // AT32F415
+#if defined(AT32F415RCT7) || defined(AT32F415RCT7_7) || defined(AT32F415CCT7) ||   \
+    defined(AT32F415CCU7) || defined(AT32F415KCU7_4) || defined(AT32F415RBT7) ||   \
+    defined(AT32F415RBT7_7) || defined(AT32F415CBT7) || defined(AT32F415CBU7) ||   \
+    defined(AT32F415KBU7_4) || defined(AT32F415R8T7) || defined(AT32F415R8T7_7) || \
+    defined(AT32F415C8T7) || defined(AT32F415K8U7_4)
+    return ((1 << 16) | (1 << 18) | (1 << 19) | (1 << 21));
+#else
+    return ((1 << 16) | (1 << 21));
+#endif
 #endif
 }
 
 uint32_t usbh_get_dwc2_gccfg_conf(void)
 {
 #ifdef CONFIG_USB_DWC2_ULPI_PHY
-    return (1 << 16);
+    return ((1 << 16) | (1 << 21));
 #else
-    return (1 << 16);
+    // AT32F415
+#if defined(AT32F415RCT7) || defined(AT32F415RCT7_7) || defined(AT32F415CCT7) ||   \
+    defined(AT32F415CCU7) || defined(AT32F415KCU7_4) || defined(AT32F415RBT7) ||   \
+    defined(AT32F415RBT7_7) || defined(AT32F415CBT7) || defined(AT32F415CBU7) ||   \
+    defined(AT32F415KBU7_4) || defined(AT32F415R8T7) || defined(AT32F415R8T7_7) || \
+    defined(AT32F415C8T7) || defined(AT32F415K8U7_4)
+    return ((1 << 16) | (1 << 18) | (1 << 19) | (1 << 21));
+#else
+    return ((1 << 16) | (1 << 21));
+#endif
 #endif
 }


### PR DESCRIPTION
Also add AT32F415 GCCFG comment, which is different from other AT32.Test slave mode only.