### PR TITLE
core: host: add "." to section usbh_class_info for IAR

### DIFF
--- a/core/usbh_core.c
+++ b/core/usbh_core.c
@@ -683,8 +683,8 @@ int usbh_initialize(uint8_t busid, uint32_t reg_base)
     usbh_class_info_table_begin = (struct usbh_class_info *)&__usbh_class_info_start__;
     usbh_class_info_table_end = (struct usbh_class_info *)&__usbh_class_info_end__;
 #elif defined(__ICCARM__) || defined(__ICCRX__) || defined(__ICCRISCV__)
-    usbh_class_info_table_begin = (struct usbh_class_info *)__section_begin("usbh_class_info");
-    usbh_class_info_table_end = (struct usbh_class_info *)__section_end("usbh_class_info");
+    usbh_class_info_table_begin = (struct usbh_class_info *)__section_begin(".usbh_class_info");
+    usbh_class_info_table_end = (struct usbh_class_info *)__section_end(".usbh_class_info");
 #endif
     usbh_hub_initialize(bus);
     return 0;

--- a/core/usbh_core.h
+++ b/core/usbh_core.h
@@ -39,8 +39,8 @@ extern "C" {
 #elif defined(__GNUC__)
 #define CLASS_INFO_DEFINE __attribute__((section(".usbh_class_info"))) __USED __ALIGNED(1)
 #elif defined(__ICCARM__) || defined(__ICCRX__) || defined(__ICCRISCV__)
-#pragma section = "usbh_class_info"
-#define CLASS_INFO_DEFINE __attribute__((section("usbh_class_info"))) __USED __ALIGNED(1)
+#pragma section = ".usbh_class_info"
+#define CLASS_INFO_DEFINE __attribute__((section(".usbh_class_info"))) __USED __ALIGNED(1)
 #endif
 
 #define USBH_GET_URB_INTERVAL(interval, speed) (speed < USB_SPEED_HIGH ? interval: (1 << (interval - 1)))


### PR DESCRIPTION
GCC使用的是".usbh_class_info"，IAR和Keil使用的没有带点。
我们使用IAR时，icf文件从segger移植过来的，section是带点的，故我将源码调整了一下。

为了将section usbh_class_info统一风格，建议对Keil的形式也加个点，不过这影响可能会比较大，对应的linker文件需要调整，请权衡。
