### PR TITLE
GD32F305RE用作device时, VBUS电压需要设置为一直有效

### DIFF
--- a/port/dwc2/usb_glue_gd.c
+++ b/port/dwc2/usb_glue_gd.c
@@ -13,7 +13,7 @@ uint32_t usbd_get_dwc2_gccfg_conf(uint32_t reg_base)
 #ifdef CONFIG_USB_HS
     return 0;
 #else
-    return ((1 << 16) | (1 << 18) | (1 << 19));
+    return ((1 << 16) | (1 << 18) | (1 << 19) | (1 << 21));
 #endif
 }
 


### PR DESCRIPTION
使用GD32F305RE用作devcie时，VBUS电压需要设置为一直有效，才能正常枚举；即USB_OTG_GLB->GCCFG bit21需要置1操作；（官方库中有对应操作）
用作主机时，该bit位是否需要置1，暂时还未确认；