### PR TITLE
Update usbh_hub.c

### DIFF
--- a/class/hub/usbh_hub.c
+++ b/class/hub/usbh_hub.c
@@ -91,7 +91,7 @@ static int _usbh_hub_get_hub_descriptor(struct usbh_hub *hub, uint8_t *buffer)
     if (ret < 0) {
         return ret;
     }
-    memcpy(buffer, g_hub_buf, USB_SIZEOF_HUB_DESC);
+    memcpy(buffer, &g_hub_buf[hub->bus->busid], USB_SIZEOF_HUB_DESC);
     return ret;
 }
 #if 0

--- a/port/dwc2/usb_hc_dwc2.c
+++ b/port/dwc2/usb_hc_dwc2.c
@@ -811,7 +811,6 @@ int usbh_kill_urb(struct usbh_urb *urb)
     urb->errorcode = -USB_ERR_SHUTDOWN;
 
     if (urb->timeout) {
-        urb->timeout = 0;
         usb_osal_sem_give(chan->waitsem);
     } else {
         dwc2_chan_free(chan);

--- a/port/ehci/usb_hc_ehci.c
+++ b/port/ehci/usb_hc_ehci.c
@@ -1258,7 +1258,6 @@ int usbh_kill_urb(struct usbh_urb *urb)
     qh->urb = NULL;
 
     if (urb->timeout) {
-        urb->timeout = 0;
         usb_osal_sem_give(qh->waitsem);
     } else {
         ehci_qh_free(bus, qh);

--- a/port/musb/usb_hc_musb.c
+++ b/port/musb/usb_hc_musb.c
@@ -705,7 +705,6 @@ int usbh_kill_urb(struct usbh_urb *urb)
     pipe->urb = NULL;
 
     if (urb->timeout) {
-        urb->timeout = 0;
         usb_osal_sem_give(pipe->waitsem);
     } else {
         musb_pipe_free(pipe);


### PR DESCRIPTION
Fix an error :
When initializing usb host with busid not equal zero, like "usbh_initialize(1, CONFIG_HPM_USBH_BASE); ", then a hub will not be recognized as normal. Usually got an error "[E/usbh_hub] invalid device bLength 0xXX".

您好，我最近在先楫6750上调USB，发现如果初始化usbhost时busid不为0，那么hub不会被正确识别。此修改可规避这个问题，但我不确定是否为最正确的修复方式。
