### PR TITLE
已在hc32f4a0上测试usbd的usb_glue_hc.c

### DIFF
--- a/port/dwc2/usb_glue_hc.c
+++ b/port/dwc2/usb_glue_hc.c
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2024, sakumisu
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include "usb_config.h"
+#include "usb_dwc2_reg.h"
+
+/* When using [GPIO_SetFunc(USBF_VBUS_PORT, USBF_VBUS_PIN, USBF_VBUS_FUNC);], there is no need to configure GOTGCTL */
+
+#define USB_OTG_GLB ((DWC2_GlobalTypeDef *)(reg_base))
+
+uint32_t usbd_get_dwc2_gccfg_conf(uint32_t reg_base)
+{
+
+    USB_OTG_GLB->GOTGCTL |= USB_OTG_GOTGCTL_BVALOEN;
+    USB_OTG_GLB->GOTGCTL |= USB_OTG_GOTGCTL_BVALOVAL;
+    return 0;
+}
+
+uint32_t usbh_get_dwc2_gccfg_conf(uint32_t reg_base)
+{
+    USB_OTG_GLB->GOTGCTL &= ~USB_OTG_GOTGCTL_BVALOEN;
+    USB_OTG_GLB->GOTGCTL &= ~USB_OTG_GOTGCTL_BVALOVAL;
+    return 0;
+}


### PR DESCRIPTION
在hc32上只需要配置对应的时钟，IO口以及中断函数，就可以使用cherryusb
![VeryCapture_20240608173715](https://github.com/cherry-embedded/CherryUSB/assets/53360341/8700870f-62e1-494a-a496-4b9489e74bb7)

