### PR TITLE
fix(common/usb_def.h):fix SELF_POWERED define err.

### DIFF
--- a/common/usb_def.h
+++ b/common/usb_def.h
@@ -190,7 +190,7 @@
 #define USB_CONFIG_REMOTE_WAKEUP 0x20
 #define USB_CONFIG_POWERED_MASK  0x40
 #define USB_CONFIG_BUS_POWERED   0x80
-#define USB_CONFIG_SELF_POWERED  0xC0
+#define USB_CONFIG_SELF_POWERED  0x40
 
 /* bMaxPower in Configuration Descriptor */
 #define USB_CONFIG_POWER_MA(mA) ((mA) / 2)


### PR DESCRIPTION
Configuration Descriptor的bmAttributes中：
1) 第6位是SELF_POWERED。
2) 第7位固定是1。