### PR TITLE
根据hid协议格式，修改usb_hid_mouse_report数据类型

### DIFF
--- a/class/hid/usb_hid.h
+++ b/class/hid/usb_hid.h
@@ -569,7 +569,7 @@ struct usb_hid_mouse_report
   int8_t ydisp;     /* y displacement */
                      /* Device specific additional bytes may follow */
 #ifdef CONFIG_INPUT_MOUSE_WHEEL
-  uint8_t wdisp;     /* Wheel displacement */
+  int8_t wdisp;     /* Wheel displacement */
 #endif
 };
 

--- a/class/hid/usb_hid.h
+++ b/class/hid/usb_hid.h
@@ -564,8 +564,8 @@ struct usb_hid_kbd_report
 /* Mouse input report (HID B.2) */
 struct usb_hid_mouse_report
 {
-  uint8_t buttons;   /* See HID_MOUSE_INPUT_BUTTON_* definitions */
-  uint8_t xdisp;     /* X displacement */
+  int8_t buttons;   /* See HID_MOUSE_INPUT_BUTTON_* definitions */
+  int8_t xdisp;     /* X displacement */
   uint8_t ydisp;     /* y displacement */
                      /* Device specific additional bytes may follow */
 #ifdef CONFIG_INPUT_MOUSE_WHEEL
@@ -576,8 +576,8 @@ struct usb_hid_mouse_report
 /* Joystick input report (1 bytes) (HID D.1) */
 struct usb_hid_js_report
 {
-  uint8_t xpos;      /* X position */
-  uint8_t ypos;      /* X position */
+  int8_t xpos;      /* X position */
+  int8_t ypos;      /* X position */
   uint8_t buttons;   /* See USBHID_JSIN_* definitions */
   uint8_t throttle;  /* Throttle */
 };

--- a/class/hid/usb_hid.h
+++ b/class/hid/usb_hid.h
@@ -569,7 +569,7 @@ struct usb_hid_mouse_report
   int8_t ydisp;     /* y displacement */
                      /* Device specific additional bytes may follow */
 #ifdef CONFIG_INPUT_MOUSE_WHEEL
-  int8_t wdisp;     /* Wheel displacement */
+  uint8_t wdisp;     /* Wheel displacement */
 #endif
 };
 

--- a/class/hid/usb_hid.h
+++ b/class/hid/usb_hid.h
@@ -566,7 +566,7 @@ struct usb_hid_mouse_report
 {
   int8_t buttons;   /* See HID_MOUSE_INPUT_BUTTON_* definitions */
   int8_t xdisp;     /* X displacement */
-  uint8_t ydisp;     /* y displacement */
+  int8_t ydisp;     /* y displacement */
                      /* Device specific additional bytes may follow */
 #ifdef CONFIG_INPUT_MOUSE_WHEEL
   uint8_t wdisp;     /* Wheel displacement */


### PR DESCRIPTION
以下是我在官网上看到的hid report例子，在使用cherryusb 开发时，鼠标报上来的数据原仓库中是uint8，范围为：0-256，在鼠标进行移动时，数据应有正负，表示前后或者上下，因此解决方法两种：1.建议采用init类型。2.另外一种解决方法是，不更改数据类型，在应用处理中要对报上来的数据进行二次处理，将相对位置表示出来，但此种方法比较麻烦。是否进行修改合入，麻烦斟酌考虑一下。
![device-class-definition-hid-111](https://github.com/user-attachments/assets/ff68dc5c-dbf0-419b-a32c-e1161909833b)
![mouse_report](https://github.com/user-attachments/assets/5cd08f6e-d01c-49e6-9a5b-665ac1610b63)
