### PR TITLE
change hid_mouse_report

### DIFF
--- a/class/hid/usb_hid.h
+++ b/class/hid/usb_hid.h
@@ -565,19 +565,17 @@ struct usb_hid_kbd_report
 struct usb_hid_mouse_report
 {
   uint8_t buttons;   /* See HID_MOUSE_INPUT_BUTTON_* definitions */
-  uint8_t xdisp;     /* X displacement */
-  uint8_t ydisp;     /* y displacement */
+  int8_t xdisp;     /* X displacement */
+  int8_t ydisp;     /* y displacement */
                      /* Device specific additional bytes may follow */
-#ifdef CONFIG_INPUT_MOUSE_WHEEL
   uint8_t wdisp;     /* Wheel displacement */
-#endif
 };
 
 /* Joystick input report (1 bytes) (HID D.1) */
 struct usb_hid_js_report
 {
-  uint8_t xpos;      /* X position */
-  uint8_t ypos;      /* X position */
+  int8_t xpos;      /* X position */
+  int8_t ypos;      /* X position */
   uint8_t buttons;   /* See USBHID_JSIN_* definitions */
   uint8_t throttle;  /* Throttle */
 };


### PR DESCRIPTION
修改usb_hid.h中usb_hid_mouse_report结构体数据类型为int8_t，删除#ifdef CONFIG_INPUT_MOUSE_WHEEL条件，我在官网上看到的hid report例子，在使用cherryusb 开发时，鼠标报上来的数据原仓库中是uint8，范围为：0-256，在鼠标进行移动时，数据应有正负，表示前后或者上下，故应为int8_t类型，表示正负