### PR TITLE
Fix the bug that USBD_EVENT_DEINIT was not notified correctly

### DIFF
--- a/core/usbd_core.c
+++ b/core/usbd_core.c
@@ -1397,9 +1397,9 @@ int usbd_initialize(uint8_t busid, uint32_t reg_base, void (*event_handler)(uint
 
 int usbd_deinitialize(uint8_t busid)
 {
-    g_usbd_core[busid].intf_offset = 0;
-    usb_dc_deinit(busid);
-    usbd_class_event_notify_handler(busid, USBD_EVENT_DEINIT, NULL);
     g_usbd_core[busid].event_handler(busid, USBD_EVENT_DEINIT);
+    usbd_class_event_notify_handler(busid, USBD_EVENT_DEINIT, NULL);
+    usb_dc_deinit(busid);
+    g_usbd_core[busid].intf_offset = 0;
     return 0;
 }


### PR DESCRIPTION
由于 usbd_class_event_notify_handler 函数中基于 intf_offset 遍历 class，先将 intf_offset 置为 0，导致 usbd_class_event_notify_handler(busid, USBD_EVENT_DEINIT, NULL); 不会正确通知 USBD_EVENT_DEINIT 事件。usbd_deinitialize 中的执行顺序根据 usbd_initialize 中取反