### PR TITLE
fix:(port/ch32/ch58x_dc_usbfs)  When CONFIG_USBDEV_EP_NUM = 4, the usb_dc_cfg.ep_out[0].ep_ram_addr address points to an exception, resulting in an empty receive Setup

### DIFF
--- a/port/ch32/usb_ch58x_dc_usbfs.c
+++ b/port/ch32/usb_ch58x_dc_usbfs.c
@@ -145,9 +145,10 @@ int usb_dc_init(uint8_t busid)
     usb_dc_cfg.ep_in[3].ep_ram_addr = ep3_data_buff + 64;
     usb_dc_cfg.ep_out[3].ep_ram_addr = ep3_data_buff;
 
+#if (CONFIG_USBDEV_EP_NUM == 8)
     usb_dc_cfg.ep_in[4].ep_ram_addr = ep0_data_buff + 64 + EP4_OUT_MPS;
     usb_dc_cfg.ep_out[4].ep_ram_addr = ep0_data_buff + 64;
-#if (CONFIG_USBDEV_EP_NUM == 8)
+
     usb_dc_cfg.ep_in[5].ep_ram_addr = ep5_data_buff + 64;
     usb_dc_cfg.ep_out[5].ep_ram_addr = ep5_data_buff;
 


### PR DESCRIPTION
- https://github.com/cherry-embedded/CherryUSB/issues/232
- 如该issue所述现象

- 经过分析可得,`usb_dc_cfg.ep_out[0].ep_ram_addr`指针指向地址异常被修改为错误地址,导致接收到的数据为空,进而导致枚举失败

```log
CherryUSB device cdc acm example
ep0_data_buff 0x20005674
usb_dc_cfg.ep_in[0].ep_ram_addr 0x20005674
usb_dc_cfg.ep_out[0].ep_ram_addr 0x20005674
ep0_data_buff 0x20005674
usb_dc_cfg.ep_in[0].ep_ram_addr 0x20005674
usb_dc_cfg.ep_out[0].ep_ram_addr 0x20005674
ep0_data_buff 0x20005674
usb_dc_cfg.ep_in[0].ep_ram_addr 0x20005674
usb_dc_cfg.ep_out[0].ep_ram_addr 0x20005674
ep0_data_buff 0x20005674
usb_dc_cfg.ep_in[0].ep_ram_addr 0x20005674
usb_dc_cfg.ep_out[0].ep_ram_addr 0x20005674
ep0_data_buff 0x20005674
usb_dc_cfg.ep_in[0].ep_ram_addr 0x20005674
usb_dc_cfg.ep_out[0].ep_ram_addr 0x200056f4
ep0_data_buff 0x20005674
usb_dc_cfg.ep_in[0].ep_ram_addr 0x20005674
usb_dc_cfg.ep_out[0].ep_ram_addr 0x200056f4
usb_dc_low_level_init
[I/USB] Setup: bmRequestType 0x00, bRequest 0x00, wValue 0x0000, wIndex 0x0000, wLength 0x0000
[D/USB] EP0 recv out status
[I/USB] Setup: bmRequestType 0x00, bRequest 0x00, wValue 0x0000, wIndex 0x0000, wLength 0x0000
[D/USB] EP0 recv out status
[I/USB] Setup: bmRequestType 0x00, bRequest 0x00, wValue 0x0000, wIndex 0x0000, wLength 0x0000
[D/USB] EP0 recv out status
[I/USB] Setup: bmRequestType 0x00, bRequest 0x00, wValue 0x0000, wIndex 0x0000, wLength 0x0000
[D/USB] EP0 recv out status
```

- 此处代码未放在`CONFIG_USBDEV_EP_NUM == 8`的宏定义内容中,导致数组溢出
```c
    usb_dc_cfg.ep_in[4].ep_ram_addr = ep0_data_buff + 64 + EP4_OUT_MPS;
    usb_dc_cfg.ep_out[4].ep_ram_addr = ep0_data_buff + 64;
```


- 修改后表现正常,测试芯片CH571

```c
CherryUSB device cdc acm example
ep0_data_buff 0x20005674
usb_dc_cfg.ep_in[0].ep_ram_addr 0x20005674
usb_dc_cfg.ep_out[0].ep_ram_addr 0x20005674
usb_dc_low_level_init
[I/USB] Setup: bmRequestType 0x80, bRequest 0x06, wValue 0x0100, wIndex 0x0000, wLength 0x0040
[D/USB] EP0 send 18 bytes, 0 remained
[D/USB] EP0 recv out status
[I/USB] Setup: bmRequestType 0x00, bRequest 0x05, wValue 0x002b, wIndex 0x0000, wLength 0x0000
[I/USB] Setup: bmRequestType 0x80, bRequest 0x06, wValue 0x0100, wIndex 0x0000, wLength 0x0012
[D/USB] EP0 send 18 bytes, 0 remained
[D/USB] EP0 recv out status
[I/USB] Setup: bmRequestType 0x80, bRequest 0x06, wValue 0x0200, wIndex 0x0000, wLength 0x00ff
```