### PR TITLE
fix(port/dwc2): fix typo

### DIFF
--- a/port/dwc2/usb_dc_dwc2.c
+++ b/port/dwc2/usb_dc_dwc2.c
@@ -119,7 +119,7 @@ USB_NOCACHE_RAM_SECTION struct dwc2_udc {
     __attribute__((aligned(32))) struct usb_setup_packet setup;
     struct dwc2_ep_state in_ep[CONFIG_USBDEV_EP_NUM];  /*!< IN endpoint parameters*/
     struct dwc2_ep_state out_ep[CONFIG_USBDEV_EP_NUM]; /*!< OUT endpoint parameters */
-} g_dwc2_udc[CONFIG_USBHOST_MAX_BUS];
+} g_dwc2_udc[CONFIG_USBDEV_MAX_BUS];
 
 static inline int dwc2_reset(uint8_t busid)
 {


### PR DESCRIPTION
fix typo in /port/dwc2/usb_dc_dwc2.c: rename CONFIG_USBHOST_MAX_BUS to CONFIG_USBDEV_MAX_BUS