### PR TITLE
fix(core/usbh_core): Fix raw_config_desc heap out of bounds

### DIFF
--- a/core/usbh_core.c
+++ b/core/usbh_core.c
@@ -486,7 +486,7 @@ int usbh_enumerate(struct usbh_hubport *hport)
         goto errout;
     }
     USB_LOG_INFO("The device has %d interfaces\r\n", ((struct usb_configuration_descriptor *)ep0_request_buffer[hport->bus->busid])->bNumInterfaces);
-    hport->raw_config_desc = usb_osal_malloc(wTotalLength);
+    hport->raw_config_desc = usb_osal_malloc(wTotalLength + 1);
     if (hport->raw_config_desc == NULL) {
         ret = -USB_ERR_NOMEM;
         USB_LOG_ERR("No memory to alloc for raw_config_desc\r\n");


### PR DESCRIPTION
这里会raw_config_desc内存访问越界。
hport->raw_config_desc[wTotalLength] = '\0';