### PR TITLE
fix: usbd_set_interface close unexpected endpoint

### DIFF
--- a/core/usbd_core.c
+++ b/core/usbd_core.c
@@ -447,6 +447,7 @@ static bool usbd_set_configuration(uint8_t busid, uint8_t config_index, uint8_t 
 static bool usbd_set_interface(uint8_t busid, uint8_t iface, uint8_t alt_setting)
 {
     const uint8_t *if_desc = NULL;
+    struct usb_endpoint_descriptor *found_ep_desc = NULL;
     struct usb_endpoint_descriptor *ep_desc;
     uint8_t cur_alt_setting = 0xFF;
     uint8_t cur_iface = 0xFF;
@@ -481,7 +482,7 @@ static bool usbd_set_interface(uint8_t busid, uint8_t iface, uint8_t alt_setting
                     if_desc = (void *)p;
                 }
 
-                USB_LOG_DBG("Current iface %u alt setting %u",
+                USB_LOG_DBG("Current iface %u alt setting %u\r\n",
                             cur_iface, cur_alt_setting);
                 break;
 
@@ -492,7 +493,7 @@ static bool usbd_set_interface(uint8_t busid, uint8_t iface, uint8_t alt_setting
                     if (cur_alt_setting != alt_setting) {
                         ret = usbd_reset_endpoint(busid, ep_desc);
                     } else {
-                        ret = usbd_set_endpoint(busid, ep_desc);
+                        found_ep_desc = ep_desc;
                     }
                 }
 
@@ -508,6 +509,10 @@ static bool usbd_set_interface(uint8_t busid, uint8_t iface, uint8_t alt_setting
         if (current_desc_len >= desc_len && desc_len) {
             break;
         }
+    }
+
+    if (found_ep_desc != NULL) {
+        ret = usbd_set_endpoint(busid, found_ep_desc);
     }
 
     usbd_class_event_notify_handler(busid, USBD_EVENT_SET_INTERFACE, (void *)if_desc);


### PR DESCRIPTION
当一个Interface多个AlternateSetting的时候，比如下面描述符的情况，当设置interface 1, alt setting 1时，会在遍历到alt setting 2时错误地关闭endpoint 2
```
        ---------------- Interface Descriptor -----------------
bLength                  : 0x09 (9 bytes)
bDescriptorType          : 0x04 (Interface Descriptor)
bInterfaceNumber         : 0x01 (Interface 1)
bAlternateSetting        : 0x01
bNumEndpoints            : 0x02 (2 Endpoints)
bInterfaceClass          : 0x01 (Audio)
bInterfaceSubClass       : 0x02 (Audio Streaming)
bInterfaceProtocol       : 0x20 (Device Protocol Version 2.0)
iInterface               : 0x00 (No String Descriptor)
Data (HexDump)           : 09 04 01 01 02 01 02 20 00                       

 ....... .

        ---------------- Interface Descriptor -----------------
bLength                  : 0x09 (9 bytes)
bDescriptorType          : 0x04 (Interface Descriptor)
bInterfaceNumber         : 0x01 (Interface 1)
bAlternateSetting        : 0x02
bNumEndpoints            : 0x02 (2 Endpoints)
bInterfaceClass          : 0x01 (Audio)
bInterfaceSubClass       : 0x02 (Audio Streaming)
bInterfaceProtocol       : 0x20 (Device Protocol Version 2.0)
iInterface               : 0x00 (No String Descriptor)
Data (HexDump)           : 09 04 01 02 02 01 02 20 00      
```