### PR TITLE
Reduce size of HID class request buffer

### DIFF
--- a/class/hid/usbh_hid.c
+++ b/class/hid/usbh_hid.c
@@ -20,7 +20,7 @@
 #define INTF_DESC_bInterfaceNumber  2 /** Interface number offset */
 #define INTF_DESC_bAlternateSetting 3 /** Alternate setting offset */
 
-USB_NOCACHE_RAM_SECTION USB_MEM_ALIGNX uint8_t g_hid_buf[CONFIG_USBHOST_MAX_HID_CLASS][USB_ALIGN_UP(256, CONFIG_USB_ALIGN_SIZE)];
+USB_NOCACHE_RAM_SECTION USB_MEM_ALIGNX uint8_t g_hid_buf[CONFIG_USBHOST_MAX_HID_CLASS][USB_ALIGN_UP(64, CONFIG_USB_ALIGN_SIZE)];
 
 static struct usbh_hid g_hid_class[CONFIG_USBHOST_MAX_HID_CLASS];
 static uint32_t g_devinuse = 0;


### PR DESCRIPTION
With the change from cherry-embedded#260, this buffer no longer needs to be so large.  It can be reduced to the save a lot of memory.

The only reason this buffer was 256 bytes was to accommodate the descriptor request.  With that now changed, 64 bytes should be more than enough.

Since CherryUSB statically allocates a lot of data structures, this should save quite a bit of memory when a host is configured to support multiple HID devices.