### PR TITLE
fix: rename class to class_code, for c++ compatibility

### DIFF
--- a/class/audio/usbh_audio.c
+++ b/class/audio/usbh_audio.c
@@ -537,8 +537,8 @@ const struct usbh_class_driver audio_streaming_class_driver = {
 
 CLASS_INFO_DEFINE const struct usbh_class_info audio_ctrl_intf_class_info = {
     .match_flags = USB_CLASS_MATCH_INTF_CLASS | USB_CLASS_MATCH_INTF_SUBCLASS,
-    .class = USB_DEVICE_CLASS_AUDIO,
-    .subclass = AUDIO_SUBCLASS_AUDIOCONTROL,
+    .class_code = USB_DEVICE_CLASS_AUDIO,
+    .subclass_code = AUDIO_SUBCLASS_AUDIOCONTROL,
     .protocol = 0x00,
     .id_table = NULL,
     .class_driver = &audio_ctrl_class_driver
@@ -546,8 +546,8 @@ CLASS_INFO_DEFINE const struct usbh_class_info audio_ctrl_intf_class_info = {
 
 CLASS_INFO_DEFINE const struct usbh_class_info audio_streaming_intf_class_info = {
     .match_flags = USB_CLASS_MATCH_INTF_CLASS | USB_CLASS_MATCH_INTF_SUBCLASS,
-    .class = USB_DEVICE_CLASS_AUDIO,
-    .subclass = AUDIO_SUBCLASS_AUDIOSTREAMING,
+    .class_code = USB_DEVICE_CLASS_AUDIO,
+    .subclass_code = AUDIO_SUBCLASS_AUDIOSTREAMING,
     .protocol = 0x00,
     .id_table = NULL,
     .class_driver = &audio_streaming_class_driver

--- a/class/audio/usbh_audio.c
+++ b/class/audio/usbh_audio.c
@@ -537,18 +537,18 @@ const struct usbh_class_driver audio_streaming_class_driver = {
 
 CLASS_INFO_DEFINE const struct usbh_class_info audio_ctrl_intf_class_info = {
     .match_flags = USB_CLASS_MATCH_INTF_CLASS | USB_CLASS_MATCH_INTF_SUBCLASS,
-    .class_code = USB_DEVICE_CLASS_AUDIO,
-    .subclass_code = AUDIO_SUBCLASS_AUDIOCONTROL,
-    .protocol = 0x00,
+    .bInterfaceClass = USB_DEVICE_CLASS_AUDIO,
+    .bInterfaceSubClass = AUDIO_SUBCLASS_AUDIOCONTROL,
+    .bInterfaceProtocol = 0x00,
     .id_table = NULL,
     .class_driver = &audio_ctrl_class_driver
 };
 
 CLASS_INFO_DEFINE const struct usbh_class_info audio_streaming_intf_class_info = {
     .match_flags = USB_CLASS_MATCH_INTF_CLASS | USB_CLASS_MATCH_INTF_SUBCLASS,
-    .class_code = USB_DEVICE_CLASS_AUDIO,
-    .subclass_code = AUDIO_SUBCLASS_AUDIOSTREAMING,
-    .protocol = 0x00,
+    .bInterfaceClass = USB_DEVICE_CLASS_AUDIO,
+    .bInterfaceSubClass = AUDIO_SUBCLASS_AUDIOSTREAMING,
+    .bInterfaceProtocol = 0x00,
     .id_table = NULL,
     .class_driver = &audio_streaming_class_driver
 };

--- a/class/cdc/usbh_cdc_acm.c
+++ b/class/cdc/usbh_cdc_acm.c
@@ -267,18 +267,18 @@ const struct usbh_class_driver cdc_data_class_driver = {
 
 CLASS_INFO_DEFINE const struct usbh_class_info cdc_acm_class_info = {
     .match_flags = USB_CLASS_MATCH_INTF_CLASS | USB_CLASS_MATCH_INTF_SUBCLASS,
-    .class = USB_DEVICE_CLASS_CDC,
-    .subclass = CDC_ABSTRACT_CONTROL_MODEL,
-    .protocol = 0x00,
+    .bInterfaceClass = USB_DEVICE_CLASS_CDC,
+    .bInterfaceSubClass = CDC_ABSTRACT_CONTROL_MODEL,
+    .bInterfaceProtocol = 0x00,
     .id_table = NULL,
     .class_driver = &cdc_acm_class_driver
 };
 
 CLASS_INFO_DEFINE const struct usbh_class_info cdc_data_class_info = {
     .match_flags = USB_CLASS_MATCH_INTF_CLASS,
-    .class = USB_DEVICE_CLASS_CDC_DATA,
-    .subclass = 0x00,
-    .protocol = 0x00,
+    .bInterfaceClass = USB_DEVICE_CLASS_CDC_DATA,
+    .bInterfaceSubClass = 0x00,
+    .bInterfaceProtocol = 0x00,
     .id_table = NULL,
     .class_driver = &cdc_data_class_driver
 };

--- a/class/cdc/usbh_cdc_ecm.c
+++ b/class/cdc/usbh_cdc_ecm.c
@@ -323,9 +323,9 @@ const struct usbh_class_driver cdc_ecm_class_driver = {
 
 CLASS_INFO_DEFINE const struct usbh_class_info cdc_ecm_class_info = {
     .match_flags = USB_CLASS_MATCH_INTF_CLASS | USB_CLASS_MATCH_INTF_SUBCLASS | USB_CLASS_MATCH_INTF_PROTOCOL,
-    .class_code = USB_DEVICE_CLASS_CDC,
-    .subclass_code = CDC_ETHERNET_NETWORKING_CONTROL_MODEL,
-    .protocol = CDC_COMMON_PROTOCOL_NONE,
+    .bInterfaceClass = USB_DEVICE_CLASS_CDC,
+    .bInterfaceSubClass = CDC_ETHERNET_NETWORKING_CONTROL_MODEL,
+    .bInterfaceProtocol = CDC_COMMON_PROTOCOL_NONE,
     .id_table = NULL,
     .class_driver = &cdc_ecm_class_driver
 };

--- a/class/cdc/usbh_cdc_ecm.c
+++ b/class/cdc/usbh_cdc_ecm.c
@@ -323,8 +323,8 @@ const struct usbh_class_driver cdc_ecm_class_driver = {
 
 CLASS_INFO_DEFINE const struct usbh_class_info cdc_ecm_class_info = {
     .match_flags = USB_CLASS_MATCH_INTF_CLASS | USB_CLASS_MATCH_INTF_SUBCLASS | USB_CLASS_MATCH_INTF_PROTOCOL,
-    .class = USB_DEVICE_CLASS_CDC,
-    .subclass = CDC_ETHERNET_NETWORKING_CONTROL_MODEL,
+    .class_code = USB_DEVICE_CLASS_CDC,
+    .subclass_code = CDC_ETHERNET_NETWORKING_CONTROL_MODEL,
     .protocol = CDC_COMMON_PROTOCOL_NONE,
     .id_table = NULL,
     .class_driver = &cdc_ecm_class_driver

--- a/class/cdc/usbh_cdc_ncm.c
+++ b/class/cdc/usbh_cdc_ncm.c
@@ -403,9 +403,9 @@ const struct usbh_class_driver cdc_ncm_class_driver = {
 
 CLASS_INFO_DEFINE const struct usbh_class_info cdc_ncm_class_info = {
     .match_flags = USB_CLASS_MATCH_INTF_CLASS | USB_CLASS_MATCH_INTF_SUBCLASS | USB_CLASS_MATCH_INTF_PROTOCOL,
-    .class_code = USB_DEVICE_CLASS_CDC,
-    .subclass_code = CDC_NETWORK_CONTROL_MODEL,
-    .protocol = CDC_COMMON_PROTOCOL_NONE,
+    .bInterfaceClass = USB_DEVICE_CLASS_CDC,
+    .bInterfaceSubClass = CDC_NETWORK_CONTROL_MODEL,
+    .bInterfaceProtocol = CDC_COMMON_PROTOCOL_NONE,
     .id_table = NULL,
     .class_driver = &cdc_ncm_class_driver
 };

--- a/class/cdc/usbh_cdc_ncm.c
+++ b/class/cdc/usbh_cdc_ncm.c
@@ -403,8 +403,8 @@ const struct usbh_class_driver cdc_ncm_class_driver = {
 
 CLASS_INFO_DEFINE const struct usbh_class_info cdc_ncm_class_info = {
     .match_flags = USB_CLASS_MATCH_INTF_CLASS | USB_CLASS_MATCH_INTF_SUBCLASS | USB_CLASS_MATCH_INTF_PROTOCOL,
-    .class = USB_DEVICE_CLASS_CDC,
-    .subclass = CDC_NETWORK_CONTROL_MODEL,
+    .class_code = USB_DEVICE_CLASS_CDC,
+    .subclass_code = CDC_NETWORK_CONTROL_MODEL,
     .protocol = CDC_COMMON_PROTOCOL_NONE,
     .id_table = NULL,
     .class_driver = &cdc_ncm_class_driver

--- a/class/hid/usbh_hid.c
+++ b/class/hid/usbh_hid.c
@@ -303,8 +303,8 @@ const struct usbh_class_driver hid_class_driver = {
 
 CLASS_INFO_DEFINE const struct usbh_class_info hid_custom_class_info = {
     .match_flags = USB_CLASS_MATCH_INTF_CLASS,
-    .class = USB_DEVICE_CLASS_HID,
-    .subclass = 0x00,
+    .class_code = USB_DEVICE_CLASS_HID,
+    .subclass_code = 0x00,
     .protocol = 0x00,
     .id_table = NULL,
     .class_driver = &hid_class_driver

--- a/class/hid/usbh_hid.c
+++ b/class/hid/usbh_hid.c
@@ -303,9 +303,9 @@ const struct usbh_class_driver hid_class_driver = {
 
 CLASS_INFO_DEFINE const struct usbh_class_info hid_custom_class_info = {
     .match_flags = USB_CLASS_MATCH_INTF_CLASS,
-    .class_code = USB_DEVICE_CLASS_HID,
-    .subclass_code = 0x00,
-    .protocol = 0x00,
+    .bInterfaceClass = USB_DEVICE_CLASS_HID,
+    .bInterfaceSubClass = 0x00,
+    .bInterfaceProtocol = 0x00,
     .id_table = NULL,
     .class_driver = &hid_class_driver
 };

--- a/class/hub/usbh_hub.c
+++ b/class/hub/usbh_hub.c
@@ -734,9 +734,9 @@ const struct usbh_class_driver hub_class_driver = {
 
 CLASS_INFO_DEFINE const struct usbh_class_info hub_class_info = {
     .match_flags = USB_CLASS_MATCH_INTF_CLASS,
-    .class_code = USB_DEVICE_CLASS_HUB,
-    .subclass_code = 0,
-    .protocol = 0,
+    .bInterfaceClass = USB_DEVICE_CLASS_HUB,
+    .bInterfaceSubClass = 0,
+    .bInterfaceProtocol = 0,
     .id_table = NULL,
     .class_driver = &hub_class_driver
 };

--- a/class/hub/usbh_hub.c
+++ b/class/hub/usbh_hub.c
@@ -734,8 +734,8 @@ const struct usbh_class_driver hub_class_driver = {
 
 CLASS_INFO_DEFINE const struct usbh_class_info hub_class_info = {
     .match_flags = USB_CLASS_MATCH_INTF_CLASS,
-    .class = USB_DEVICE_CLASS_HUB,
-    .subclass = 0,
+    .class_code = USB_DEVICE_CLASS_HUB,
+    .subclass_code = 0,
     .protocol = 0,
     .id_table = NULL,
     .class_driver = &hub_class_driver

--- a/class/msc/usbh_msc.c
+++ b/class/msc/usbh_msc.c
@@ -443,9 +443,9 @@ const struct usbh_class_driver msc_class_driver = {
 
 CLASS_INFO_DEFINE const struct usbh_class_info msc_class_info = {
     .match_flags = USB_CLASS_MATCH_INTF_CLASS | USB_CLASS_MATCH_INTF_SUBCLASS | USB_CLASS_MATCH_INTF_PROTOCOL,
-    .class_code = USB_DEVICE_CLASS_MASS_STORAGE,
-    .subclass_code = MSC_SUBCLASS_SCSI,
-    .protocol = MSC_PROTOCOL_BULK_ONLY,
+    .bInterfaceClass = USB_DEVICE_CLASS_MASS_STORAGE,
+    .bInterfaceSubClass = MSC_SUBCLASS_SCSI,
+    .bInterfaceProtocol = MSC_PROTOCOL_BULK_ONLY,
     .id_table = NULL,
     .class_driver = &msc_class_driver
 };

--- a/class/msc/usbh_msc.c
+++ b/class/msc/usbh_msc.c
@@ -443,8 +443,8 @@ const struct usbh_class_driver msc_class_driver = {
 
 CLASS_INFO_DEFINE const struct usbh_class_info msc_class_info = {
     .match_flags = USB_CLASS_MATCH_INTF_CLASS | USB_CLASS_MATCH_INTF_SUBCLASS | USB_CLASS_MATCH_INTF_PROTOCOL,
-    .class = USB_DEVICE_CLASS_MASS_STORAGE,
-    .subclass = MSC_SUBCLASS_SCSI,
+    .class_code = USB_DEVICE_CLASS_MASS_STORAGE,
+    .subclass_code = MSC_SUBCLASS_SCSI,
     .protocol = MSC_PROTOCOL_BULK_ONLY,
     .id_table = NULL,
     .class_driver = &msc_class_driver

--- a/class/template/usbh_xxx.c
+++ b/class/template/usbh_xxx.c
@@ -89,9 +89,9 @@ static const struct usbh_class_driver xxx_class_driver = {
 
 CLASS_INFO_DEFINE const struct usbh_class_info xxx_class_info = {
     .match_flags = USB_CLASS_MATCH_INTF_CLASS | USB_CLASS_MATCH_INTF_SUBCLASS | USB_CLASS_MATCH_INTF_PROTOCOL,
-    .class_code = 0,
-    .subclass_code = 0,
-    .protocol = 0,
+    .bInterfaceClass = 0,
+    .bInterfaceSubClass = 0,
+    .bInterfaceProtocol = 0,
     .id_table = NULL,
     .class_driver = &xxx_class_driver
 };

--- a/class/template/usbh_xxx.c
+++ b/class/template/usbh_xxx.c
@@ -89,8 +89,8 @@ static const struct usbh_class_driver xxx_class_driver = {
 
 CLASS_INFO_DEFINE const struct usbh_class_info xxx_class_info = {
     .match_flags = USB_CLASS_MATCH_INTF_CLASS | USB_CLASS_MATCH_INTF_SUBCLASS | USB_CLASS_MATCH_INTF_PROTOCOL,
-    .class = 0,
-    .subclass = 0,
+    .class_code = 0,
+    .subclass_code = 0,
     .protocol = 0,
     .id_table = NULL,
     .class_driver = &xxx_class_driver

--- a/class/vendor/net/usbh_asix.c
+++ b/class/vendor/net/usbh_asix.c
@@ -817,9 +817,9 @@ static const struct usbh_class_driver asix_class_driver = {
 
 CLASS_INFO_DEFINE const struct usbh_class_info asix_class_info = {
     .match_flags = USB_CLASS_MATCH_VID_PID | USB_CLASS_MATCH_INTF_CLASS,
-    .class_code = 0xff,
-    .subclass_code = 0x00,
-    .protocol = 0x00,
+    .bInterfaceClass = 0xff,
+    .bInterfaceSubClass = 0x00,
+    .bInterfaceProtocol = 0x00,
     .id_table = asix_id_table,
     .class_driver = &asix_class_driver
 };

--- a/class/vendor/net/usbh_asix.c
+++ b/class/vendor/net/usbh_asix.c
@@ -817,8 +817,8 @@ static const struct usbh_class_driver asix_class_driver = {
 
 CLASS_INFO_DEFINE const struct usbh_class_info asix_class_info = {
     .match_flags = USB_CLASS_MATCH_VID_PID | USB_CLASS_MATCH_INTF_CLASS,
-    .class = 0xff,
-    .subclass = 0x00,
+    .class_code = 0xff,
+    .subclass_code = 0x00,
     .protocol = 0x00,
     .id_table = asix_id_table,
     .class_driver = &asix_class_driver

--- a/class/vendor/net/usbh_rtl8152.c
+++ b/class/vendor/net/usbh_rtl8152.c
@@ -2272,8 +2272,8 @@ static const struct usbh_class_driver rtl8152_class_driver = {
 
 CLASS_INFO_DEFINE const struct usbh_class_info rtl8152_class_info = {
     .match_flags = USB_CLASS_MATCH_VID_PID | USB_CLASS_MATCH_INTF_CLASS,
-    .class = 0xff,
-    .subclass = 0x00,
+    .class_code = 0xff,
+    .subclass_code = 0x00,
     .protocol = 0x00,
     .id_table = rtl_id_table,
     .class_driver = &rtl8152_class_driver

--- a/class/vendor/net/usbh_rtl8152.c
+++ b/class/vendor/net/usbh_rtl8152.c
@@ -2272,9 +2272,9 @@ static const struct usbh_class_driver rtl8152_class_driver = {
 
 CLASS_INFO_DEFINE const struct usbh_class_info rtl8152_class_info = {
     .match_flags = USB_CLASS_MATCH_VID_PID | USB_CLASS_MATCH_INTF_CLASS,
-    .class_code = 0xff,
-    .subclass_code = 0x00,
-    .protocol = 0x00,
+    .bInterfaceClass = 0xff,
+    .bInterfaceSubClass = 0x00,
+    .bInterfaceProtocol = 0x00,
     .id_table = rtl_id_table,
     .class_driver = &rtl8152_class_driver
 };

--- a/class/vendor/serial/usbh_ch34x.c
+++ b/class/vendor/serial/usbh_ch34x.c
@@ -370,9 +370,9 @@ const struct usbh_class_driver ch34x_class_driver = {
 
 CLASS_INFO_DEFINE const struct usbh_class_info ch34x_class_info = {
     .match_flags = USB_CLASS_MATCH_VID_PID | USB_CLASS_MATCH_INTF_CLASS,
-    .class_code = 0xff,
-    .subclass_code = 0x00,
-    .protocol = 0x00,
+    .bInterfaceClass = 0xff,
+    .bInterfaceSubClass = 0x00,
+    .bInterfaceProtocol = 0x00,
     .id_table = ch34x_id_table,
     .class_driver = &ch34x_class_driver
 };

--- a/class/vendor/serial/usbh_ch34x.c
+++ b/class/vendor/serial/usbh_ch34x.c
@@ -370,8 +370,8 @@ const struct usbh_class_driver ch34x_class_driver = {
 
 CLASS_INFO_DEFINE const struct usbh_class_info ch34x_class_info = {
     .match_flags = USB_CLASS_MATCH_VID_PID | USB_CLASS_MATCH_INTF_CLASS,
-    .class = 0xff,
-    .subclass = 0x00,
+    .class_code = 0xff,
+    .subclass_code = 0x00,
     .protocol = 0x00,
     .id_table = ch34x_id_table,
     .class_driver = &ch34x_class_driver

--- a/class/vendor/serial/usbh_cp210x.c
+++ b/class/vendor/serial/usbh_cp210x.c
@@ -319,8 +319,8 @@ const struct usbh_class_driver cp210x_class_driver = {
 
 CLASS_INFO_DEFINE const struct usbh_class_info cp210x_class_info = {
     .match_flags = USB_CLASS_MATCH_VID_PID | USB_CLASS_MATCH_INTF_CLASS,
-    .class = 0xff,
-    .subclass = 0x00,
+    .class_code = 0xff,
+    .subclass_code = 0x00,
     .protocol = 0x00,
     .id_table = cp210x_id_table,
     .class_driver = &cp210x_class_driver

--- a/class/vendor/serial/usbh_cp210x.c
+++ b/class/vendor/serial/usbh_cp210x.c
@@ -319,9 +319,9 @@ const struct usbh_class_driver cp210x_class_driver = {
 
 CLASS_INFO_DEFINE const struct usbh_class_info cp210x_class_info = {
     .match_flags = USB_CLASS_MATCH_VID_PID | USB_CLASS_MATCH_INTF_CLASS,
-    .class_code = 0xff,
-    .subclass_code = 0x00,
-    .protocol = 0x00,
+    .bInterfaceClass = 0xff,
+    .subclasbInterfaceSubClasss_code = 0x00,
+    .bInterfaceProtocol = 0x00,
     .id_table = cp210x_id_table,
     .class_driver = &cp210x_class_driver
 };

--- a/class/vendor/serial/usbh_ftdi.c
+++ b/class/vendor/serial/usbh_ftdi.c
@@ -392,9 +392,9 @@ const struct usbh_class_driver ftdi_class_driver = {
 
 CLASS_INFO_DEFINE const struct usbh_class_info ftdi_class_info = {
     .match_flags = USB_CLASS_MATCH_VID_PID | USB_CLASS_MATCH_INTF_CLASS,
-    .class_code = 0xff,
-    .subclass_code = 0x00,
-    .protocol = 0x00,
+    .bInterfaceClass = 0xff,
+    .bInterfaceSubClass = 0x00,
+    .bInterfaceProtocol = 0x00,
     .id_table = ftdi_id_table,
     .class_driver = &ftdi_class_driver
 };

--- a/class/vendor/serial/usbh_ftdi.c
+++ b/class/vendor/serial/usbh_ftdi.c
@@ -392,8 +392,8 @@ const struct usbh_class_driver ftdi_class_driver = {
 
 CLASS_INFO_DEFINE const struct usbh_class_info ftdi_class_info = {
     .match_flags = USB_CLASS_MATCH_VID_PID | USB_CLASS_MATCH_INTF_CLASS,
-    .class = 0xff,
-    .subclass = 0x00,
+    .class_code = 0xff,
+    .subclass_code = 0x00,
     .protocol = 0x00,
     .id_table = ftdi_id_table,
     .class_driver = &ftdi_class_driver

--- a/class/vendor/serial/usbh_pl2303.c
+++ b/class/vendor/serial/usbh_pl2303.c
@@ -440,8 +440,8 @@ const struct usbh_class_driver pl2303_class_driver = {
 
 CLASS_INFO_DEFINE const struct usbh_class_info pl2303_class_info = {
     .match_flags = USB_CLASS_MATCH_VID_PID | USB_CLASS_MATCH_INTF_CLASS,
-    .class = 0xff,
-    .subclass = 0x00,
+    .class_code = 0xff,
+    .subclass_code = 0x00,
     .protocol = 0x00,
     .id_table = pl2303_id_table,
     .class_driver = &pl2303_class_driver

--- a/class/vendor/serial/usbh_pl2303.c
+++ b/class/vendor/serial/usbh_pl2303.c
@@ -440,9 +440,9 @@ const struct usbh_class_driver pl2303_class_driver = {
 
 CLASS_INFO_DEFINE const struct usbh_class_info pl2303_class_info = {
     .match_flags = USB_CLASS_MATCH_VID_PID | USB_CLASS_MATCH_INTF_CLASS,
-    .class_code = 0xff,
-    .subclass_code = 0x00,
-    .protocol = 0x00,
+    .bInterfaceClass = 0xff,
+    .bInterfaceSubClass = 0x00,
+    .bInterfaceProtocol = 0x00,
     .id_table = pl2303_id_table,
     .class_driver = &pl2303_class_driver
 };

--- a/class/vendor/wifi/usbh_bl616.c
+++ b/class/vendor/wifi/usbh_bl616.c
@@ -504,8 +504,8 @@ static const struct usbh_class_driver bl616_class_driver = {
 
 CLASS_INFO_DEFINE const struct usbh_class_info bl616_class_info = {
     .match_flags = USB_CLASS_MATCH_VID_PID | USB_CLASS_MATCH_INTF_CLASS,
-    .class = 0xff,
-    .subclass = 0x00,
+    .class_code = 0xff,
+    .subclass_code = 0x00,
     .protocol = 0x00,
     .id_table = bl616_id_table,
     .class_driver = &bl616_class_driver

--- a/class/vendor/wifi/usbh_bl616.c
+++ b/class/vendor/wifi/usbh_bl616.c
@@ -504,9 +504,9 @@ static const struct usbh_class_driver bl616_class_driver = {
 
 CLASS_INFO_DEFINE const struct usbh_class_info bl616_class_info = {
     .match_flags = USB_CLASS_MATCH_VID_PID | USB_CLASS_MATCH_INTF_CLASS,
-    .class_code = 0xff,
-    .subclass_code = 0x00,
-    .protocol = 0x00,
+    .bInterfaceClass = 0xff,
+    .bInterfaceSubClass = 0x00,
+    .bInterfaceProtocol = 0x00,
     .id_table = bl616_id_table,
     .class_driver = &bl616_class_driver
 };

--- a/class/vendor/xbox/usbh_xbox.c
+++ b/class/vendor/xbox/usbh_xbox.c
@@ -220,9 +220,9 @@ static const uint16_t xbox_id_table[][2] = {
 
 CLASS_INFO_DEFINE const struct usbh_class_info xbox_custom_class_info = {
     .match_flags = USB_CLASS_MATCH_VID_PID | USB_CLASS_MATCH_INTF_CLASS | USB_CLASS_MATCH_INTF_SUBCLASS | USB_CLASS_MATCH_INTF_PROTOCOL,
-    .class_code = USB_DEVICE_CLASS_VEND_SPECIFIC,
-    .subclass_code = 0x5d,
-    .protocol = 0x01,
+    .bInterfaceClass = USB_DEVICE_CLASS_VEND_SPECIFIC,
+    .bInterfaceSubClass = 0x5d,
+    .bInterfaceProtocol = 0x01,
     .id_table =  xbox_id_table,
     .class_driver = &xbox_class_driver
 };

--- a/class/vendor/xbox/usbh_xbox.c
+++ b/class/vendor/xbox/usbh_xbox.c
@@ -220,8 +220,8 @@ static const uint16_t xbox_id_table[][2] = {
 
 CLASS_INFO_DEFINE const struct usbh_class_info xbox_custom_class_info = {
     .match_flags = USB_CLASS_MATCH_VID_PID | USB_CLASS_MATCH_INTF_CLASS | USB_CLASS_MATCH_INTF_SUBCLASS | USB_CLASS_MATCH_INTF_PROTOCOL,
-    .class = USB_DEVICE_CLASS_VEND_SPECIFIC,
-    .subclass = 0x5d,
+    .class_code = USB_DEVICE_CLASS_VEND_SPECIFIC,
+    .subclass_code = 0x5d,
     .protocol = 0x01,
     .id_table =  xbox_id_table,
     .class_driver = &xbox_class_driver

--- a/class/video/usbh_video.c
+++ b/class/video/usbh_video.c
@@ -531,8 +531,8 @@ const struct usbh_class_driver video_streaming_class_driver = {
 
 CLASS_INFO_DEFINE const struct usbh_class_info video_ctrl_class_info = {
     .match_flags = USB_CLASS_MATCH_INTF_CLASS | USB_CLASS_MATCH_INTF_SUBCLASS | USB_CLASS_MATCH_INTF_PROTOCOL,
-    .class = USB_DEVICE_CLASS_VIDEO,
-    .subclass = VIDEO_SC_VIDEOCONTROL,
+    .class_code = USB_DEVICE_CLASS_VIDEO,
+    .subclass_code = VIDEO_SC_VIDEOCONTROL,
     .protocol = VIDEO_PC_PROTOCOL_UNDEFINED,
     .id_table = NULL,
     .class_driver = &video_ctrl_class_driver
@@ -540,8 +540,8 @@ CLASS_INFO_DEFINE const struct usbh_class_info video_ctrl_class_info = {
 
 CLASS_INFO_DEFINE const struct usbh_class_info video_streaming_class_info = {
     .match_flags = USB_CLASS_MATCH_INTF_CLASS | USB_CLASS_MATCH_INTF_SUBCLASS | USB_CLASS_MATCH_INTF_PROTOCOL,
-    .class = USB_DEVICE_CLASS_VIDEO,
-    .subclass = VIDEO_SC_VIDEOSTREAMING,
+    .class_code = USB_DEVICE_CLASS_VIDEO,
+    .subclass_code = VIDEO_SC_VIDEOSTREAMING,
     .protocol = VIDEO_PC_PROTOCOL_UNDEFINED,
     .id_table = NULL,
     .class_driver = &video_streaming_class_driver

--- a/class/video/usbh_video.c
+++ b/class/video/usbh_video.c
@@ -531,18 +531,18 @@ const struct usbh_class_driver video_streaming_class_driver = {
 
 CLASS_INFO_DEFINE const struct usbh_class_info video_ctrl_class_info = {
     .match_flags = USB_CLASS_MATCH_INTF_CLASS | USB_CLASS_MATCH_INTF_SUBCLASS | USB_CLASS_MATCH_INTF_PROTOCOL,
-    .class_code = USB_DEVICE_CLASS_VIDEO,
-    .subclass_code = VIDEO_SC_VIDEOCONTROL,
-    .protocol = VIDEO_PC_PROTOCOL_UNDEFINED,
+    .bInterfaceClass = USB_DEVICE_CLASS_VIDEO,
+    .bInterfaceSubClass = VIDEO_SC_VIDEOCONTROL,
+    .bInterfaceProtocol = VIDEO_PC_PROTOCOL_UNDEFINED,
     .id_table = NULL,
     .class_driver = &video_ctrl_class_driver
 };
 
 CLASS_INFO_DEFINE const struct usbh_class_info video_streaming_class_info = {
     .match_flags = USB_CLASS_MATCH_INTF_CLASS | USB_CLASS_MATCH_INTF_SUBCLASS | USB_CLASS_MATCH_INTF_PROTOCOL,
-    .class_code = USB_DEVICE_CLASS_VIDEO,
-    .subclass_code = VIDEO_SC_VIDEOSTREAMING,
-    .protocol = VIDEO_PC_PROTOCOL_UNDEFINED,
+    .bInterfaceClass = USB_DEVICE_CLASS_VIDEO,
+    .bInterfaceSubClass = VIDEO_SC_VIDEOSTREAMING,
+    .bInterfaceProtocol = VIDEO_PC_PROTOCOL_UNDEFINED,
     .id_table = NULL,
     .class_driver = &video_streaming_class_driver
 };

--- a/class/wireless/usbh_bluetooth.c
+++ b/class/wireless/usbh_bluetooth.c
@@ -393,18 +393,18 @@ static const uint16_t bluetooth_id_table[][2] = {
 
 CLASS_INFO_DEFINE const struct usbh_class_info bluetooth_h4_nrf_class_info = {
     .match_flags = USB_CLASS_MATCH_VID_PID | USB_CLASS_MATCH_INTF_CLASS,
-    .class_code = 0xff,
-    .subclass_code = 0x00,
-    .protocol = 0x00,
+    .bInterfaceClass = 0xff,
+    .bInterfaceSubClass = 0x00,
+    .bInterfaceProtocol = 0x00,
     .id_table = bluetooth_id_table,
     .class_driver = &bluetooth_class_driver
 };
 #else
 CLASS_INFO_DEFINE const struct usbh_class_info bluetooth_class_info = {
     .match_flags = USB_CLASS_MATCH_INTF_CLASS | USB_CLASS_MATCH_INTF_SUBCLASS | USB_CLASS_MATCH_INTF_PROTOCOL,
-    .class_code = USB_DEVICE_CLASS_WIRELESS,
-    .subclass_code = 0x01,
-    .protocol = 0x01,
+    .bInterfaceClass = USB_DEVICE_CLASS_WIRELESS,
+    .bInterfaceSubClass = 0x01,
+    .bInterfaceProtocol = 0x01,
     .id_table = NULL,
     .class_driver = &bluetooth_class_driver
 };

--- a/class/wireless/usbh_bluetooth.c
+++ b/class/wireless/usbh_bluetooth.c
@@ -393,8 +393,8 @@ static const uint16_t bluetooth_id_table[][2] = {
 
 CLASS_INFO_DEFINE const struct usbh_class_info bluetooth_h4_nrf_class_info = {
     .match_flags = USB_CLASS_MATCH_VID_PID | USB_CLASS_MATCH_INTF_CLASS,
-    .class = 0xff,
-    .subclass = 0x00,
+    .class_code = 0xff,
+    .subclass_code = 0x00,
     .protocol = 0x00,
     .id_table = bluetooth_id_table,
     .class_driver = &bluetooth_class_driver
@@ -402,8 +402,8 @@ CLASS_INFO_DEFINE const struct usbh_class_info bluetooth_h4_nrf_class_info = {
 #else
 CLASS_INFO_DEFINE const struct usbh_class_info bluetooth_class_info = {
     .match_flags = USB_CLASS_MATCH_INTF_CLASS | USB_CLASS_MATCH_INTF_SUBCLASS | USB_CLASS_MATCH_INTF_PROTOCOL,
-    .class = USB_DEVICE_CLASS_WIRELESS,
-    .subclass = 0x01,
+    .class_code = USB_DEVICE_CLASS_WIRELESS,
+    .subclass_code = 0x01,
     .protocol = 0x01,
     .id_table = NULL,
     .class_driver = &bluetooth_class_driver

--- a/class/wireless/usbh_rndis.c
+++ b/class/wireless/usbh_rndis.c
@@ -600,8 +600,8 @@ static const struct usbh_class_driver rndis_class_driver = {
 
 CLASS_INFO_DEFINE const struct usbh_class_info rndis_class_info = {
     .match_flags = USB_CLASS_MATCH_INTF_CLASS | USB_CLASS_MATCH_INTF_SUBCLASS | USB_CLASS_MATCH_INTF_PROTOCOL,
-    .class = USB_DEVICE_CLASS_WIRELESS,
-    .subclass = 0x01,
+    .class_code = USB_DEVICE_CLASS_WIRELESS,
+    .subclass_code = 0x01,
     .protocol = 0x03,
     .id_table = NULL,
     .class_driver = &rndis_class_driver

--- a/class/wireless/usbh_rndis.c
+++ b/class/wireless/usbh_rndis.c
@@ -600,9 +600,9 @@ static const struct usbh_class_driver rndis_class_driver = {
 
 CLASS_INFO_DEFINE const struct usbh_class_info rndis_class_info = {
     .match_flags = USB_CLASS_MATCH_INTF_CLASS | USB_CLASS_MATCH_INTF_SUBCLASS | USB_CLASS_MATCH_INTF_PROTOCOL,
-    .class_code = USB_DEVICE_CLASS_WIRELESS,
-    .subclass_code = 0x01,
-    .protocol = 0x03,
+    .bInterfaceClass = USB_DEVICE_CLASS_WIRELESS,
+    .bInterfaceSubClass = 0x01,
+    .bInterfaceProtocol = 0x03,
     .id_table = NULL,
     .class_driver = &rndis_class_driver
 };

--- a/core/usbh_core.c
+++ b/core/usbh_core.c
@@ -93,13 +93,13 @@ static const struct usbh_class_driver *usbh_find_class_driver(uint8_t class, uin
     struct usbh_class_info *index = NULL;
 
     for (index = usbh_class_info_table_begin; index < usbh_class_info_table_end; index++) {
-        if ((index->match_flags & USB_CLASS_MATCH_INTF_CLASS) && !(index->class_code == class)) {
+        if ((index->match_flags & USB_CLASS_MATCH_INTF_CLASS) && !(index->bInterfaceClass == class)) {
             continue;
         }
-        if ((index->match_flags & USB_CLASS_MATCH_INTF_SUBCLASS) && !(index->subclass_code == subclass)) {
+        if ((index->match_flags & USB_CLASS_MATCH_INTF_SUBCLASS) && !(index->bInterfaceSubClass == subclass)) {
             continue;
         }
-        if ((index->match_flags & USB_CLASS_MATCH_INTF_PROTOCOL) && !(index->protocol == protocol)) {
+        if ((index->match_flags & USB_CLASS_MATCH_INTF_PROTOCOL) && !(index->bInterfaceProtocol == protocol)) {
             continue;
         }
         if (index->match_flags & USB_CLASS_MATCH_VID_PID && index->id_table) {

--- a/core/usbh_core.c
+++ b/core/usbh_core.c
@@ -93,10 +93,10 @@ static const struct usbh_class_driver *usbh_find_class_driver(uint8_t class, uin
     struct usbh_class_info *index = NULL;
 
     for (index = usbh_class_info_table_begin; index < usbh_class_info_table_end; index++) {
-        if ((index->match_flags & USB_CLASS_MATCH_INTF_CLASS) && !(index->class == class)) {
+        if ((index->match_flags & USB_CLASS_MATCH_INTF_CLASS) && !(index->class_code == class)) {
             continue;
         }
-        if ((index->match_flags & USB_CLASS_MATCH_INTF_SUBCLASS) && !(index->subclass == subclass)) {
+        if ((index->match_flags & USB_CLASS_MATCH_INTF_SUBCLASS) && !(index->subclass_code == subclass)) {
             continue;
         }
         if ((index->match_flags & USB_CLASS_MATCH_INTF_PROTOCOL) && !(index->protocol == protocol)) {

--- a/core/usbh_core.h
+++ b/core/usbh_core.h
@@ -61,8 +61,8 @@ extern "C" {
 
 struct usbh_class_info {
     uint8_t match_flags;           /* Used for product specific matches; range is inclusive */
-    uint8_t class;                 /* Base device class code */
-    uint8_t subclass;              /* Sub-class, depends on base class. Eg. */
+    uint8_t class_code;            /* Base device class code */
+    uint8_t subclass_code;         /* Sub-class, depends on base class. Eg. */
     uint8_t protocol;              /* Protocol, depends on base class. Eg. */
     const uint16_t (*id_table)[2]; /* List of Vendor/Product ID pairs */
     const struct usbh_class_driver *class_driver;

--- a/core/usbh_core.h
+++ b/core/usbh_core.h
@@ -61,9 +61,9 @@ extern "C" {
 
 struct usbh_class_info {
     uint8_t match_flags;           /* Used for product specific matches; range is inclusive */
-    uint8_t class_code;            /* Base device class code */
-    uint8_t subclass_code;         /* Sub-class, depends on base class. Eg. */
-    uint8_t protocol;              /* Protocol, depends on base class. Eg. */
+    uint8_t bInterfaceClass;       /* Base device class code */
+    uint8_t bInterfaceSubClass;    /* Sub-class, depends on base class. Eg. */
+    uint8_t bInterfaceProtocol;    /* Protocol, depends on base class. Eg. */
     const uint16_t (*id_table)[2]; /* List of Vendor/Product ID pairs */
     const struct usbh_class_driver *class_driver;
 };


### PR DESCRIPTION
class is a reserved word in c++, so it should not be used. Renames to class_code. Also renamed subclass to subclass_code, for consistency.

This will break vendor specific class drivers that are not in this repository.