### PR TITLE
Add callback for audio volume range (uac2 only)

### DIFF
--- a/class/audio/usbd_audio.c
+++ b/class/audio/usbd_audio.c
@@ -190,11 +190,10 @@ static int audio_class_interface_request_handler(uint8_t busid, struct usb_setup
                                 break;
                             case AUDIO_REQUEST_RANGE:
                                 if (setup->bmRequestType & USB_REQUEST_DIR_MASK) {
-                                    *((uint16_t *)(*data + 0)) = 1;
-                                    *((uint16_t *)(*data + 2)) = 0;
-                                    *((uint16_t *)(*data + 4)) = 100;
-                                    *((uint16_t *)(*data + 6)) = 1;
-                                    *len = 8;
+                                    usbd_audio_get_volume_table(busid, ep, data);
+                                    num = (uint16_t)((uint16_t)(sampling_freq_table[1] << 8) | ((uint16_t)sampling_freq_table[0]));
+                                    *len = (6 * num + 2);
+                                    memcpy(*data, sampling_freq_table, *len);
                                 } else {
                                 }
                                 break;
@@ -327,6 +326,14 @@ __WEAK int usbd_audio_get_volume(uint8_t busid, uint8_t ep, uint8_t ch)
     (void)ch;
 
     return 0;
+}
+
+__WEAK void usbd_audio_get_volume_table(uint8_t busid, uint8_t ep, uint8_t **volume_table)
+{
+    *((uint16_t *)(*volume_table + 0)) = 1;
+    *((uint16_t *)(*volume_table + 2)) = 0;
+    *((uint16_t *)(*volume_table + 4)) = 100;
+    *((uint16_t *)(*volume_table + 6)) = 1;
 }
 
 __WEAK void usbd_audio_set_mute(uint8_t busid, uint8_t ep, uint8_t ch, bool mute)

--- a/class/audio/usbd_audio.h
+++ b/class/audio/usbd_audio.h
@@ -29,7 +29,24 @@ void usbd_audio_close(uint8_t busid, uint8_t intf);
 
 void usbd_audio_set_volume(uint8_t busid, uint8_t ep, uint8_t ch, int volume);
 int usbd_audio_get_volume(uint8_t busid, uint8_t ep, uint8_t ch);
-void usbd_audio_get_volume_table(uint8_t busid, uint8_t ep, uint8_t **volume_table);
+
+/**
+ * @brief Get the volume range table for a specific endpoint. May optionally adjust the passed
+ * volume_table pointer, but can alsu wirte directly to the passed buffer.
+ * 
+ * Must fill the buffer with the following a table of entries.
+ * The first value is the number of entries. For each entry, three values have to be given, each
+ * in 1/256 dB:
+ * - minimin level
+ * - maximum level
+ * - step size
+ * 
+ * @param busid USB bus ID
+ * @param ep Endpoint address
+ * @param volume_range_table Pointer to buffer pointer.
+ */
+void usbd_audio_get_volume_table(uint8_t busid, uint8_t ep, uint16_t **volume_range_table);
+
 void usbd_audio_set_mute(uint8_t busid, uint8_t ep, uint8_t ch, bool mute);
 bool usbd_audio_get_mute(uint8_t busid, uint8_t ep, uint8_t ch);
 void usbd_audio_set_sampling_freq(uint8_t busid, uint8_t ep, uint32_t sampling_freq);

--- a/class/audio/usbd_audio.h
+++ b/class/audio/usbd_audio.h
@@ -29,6 +29,7 @@ void usbd_audio_close(uint8_t busid, uint8_t intf);
 
 void usbd_audio_set_volume(uint8_t busid, uint8_t ep, uint8_t ch, int volume);
 int usbd_audio_get_volume(uint8_t busid, uint8_t ep, uint8_t ch);
+void usbd_audio_get_volume_table(uint8_t busid, uint8_t ep, uint8_t **volume_table);
 void usbd_audio_set_mute(uint8_t busid, uint8_t ep, uint8_t ch, bool mute);
 bool usbd_audio_get_mute(uint8_t busid, uint8_t ep, uint8_t ch);
 void usbd_audio_set_sampling_freq(uint8_t busid, uint8_t ep, uint32_t sampling_freq);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new function for retrieving a volume range table, enhancing audio control capabilities.
	- Updated volume control request handling for improved modularity and functionality.

- **Bug Fixes**
	- Adjusted logic for handling request types to ensure correct operations during volume control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->