### PR TITLE
usbd_video: use pingpang buffer to improve tx performance

### DIFF
--- a/class/video/usbd_video.c
+++ b/class/video/usbd_video.c
@@ -18,7 +18,14 @@ struct usbd_video_priv {
     uint8_t power_mode;
     uint8_t error_code;
     struct video_entity_info info[3];
-    uint8_t *ep_buffer;
+    uint8_t *ep_buf0;
+    uint8_t *ep_buf1;
+    bool ep_buf0_ready;
+    bool ep_buf1_ready;
+    uint32_t ep_buf0_len;
+    uint32_t ep_buf1_len;
+    uint8_t ep_buf_idx;
+    bool stream_finish;
     uint32_t max_packets;
     uint8_t *stream_buf;
     uint32_t stream_len;
@@ -749,6 +756,40 @@ static void usbd_video_probe_and_commit_controls_init(uint8_t busid, uint32_t dw
     g_usbd_video[busid].stream_headerlen = 2;
 }
 
+static uint32_t usbd_video_prepare_ep_buf_data(uint8_t busid, uint32_t remain, uint8_t *ep_buf)
+{
+    struct video_payload_header *header;
+    uint32_t len;
+    uint32_t offset;
+
+    len = MIN(remain, (g_usbd_video[busid].probe.dwMaxPayloadTransferSize - g_usbd_video[busid].stream_headerlen) * g_usbd_video[busid].max_packets);
+    offset = 0;
+    while (len > 0) {
+        header = (struct video_payload_header *)&ep_buf[offset];
+        header->bHeaderLength = g_usbd_video[busid].stream_headerlen;
+        header->headerInfoUnion.bmheaderInfo = 0;
+        header->headerInfoUnion.headerInfoBits.endOfHeader = 1;
+        header->headerInfoUnion.headerInfoBits.endOfFrame = 0;
+        header->headerInfoUnion.headerInfoBits.frameIdentifier = g_usbd_video[busid].stream_frameid;
+
+        uint32_t len2 = MIN(len, g_usbd_video[busid].probe.dwMaxPayloadTransferSize - g_usbd_video[busid].stream_headerlen);
+
+        usb_memcpy(&ep_buf[offset + g_usbd_video[busid].stream_headerlen],
+                   &g_usbd_video[busid].stream_buf[g_usbd_video[busid].stream_offset],
+                   len2);
+
+        g_usbd_video[busid].stream_offset += len2;
+        len -= len2;
+        offset += (len2 + g_usbd_video[busid].stream_headerlen);
+
+        if (g_usbd_video[busid].stream_offset == g_usbd_video[busid].stream_len) {
+            header->headerInfoUnion.headerInfoBits.endOfFrame = 1;
+        }
+    }
+
+    return offset;
+}
+
 struct usbd_interface *usbd_video_init_intf(uint8_t busid,
                                             struct usbd_interface *intf,
                                             uint32_t dwFrameInterval,
@@ -776,55 +817,63 @@ struct usbd_interface *usbd_video_init_intf(uint8_t busid,
 
 bool usbd_video_stream_split_transfer(uint8_t busid, uint8_t ep)
 {
-    struct video_payload_header *header;
     uint32_t remain;
-    uint32_t len;
-    uint32_t offset;
 
-    remain = g_usbd_video[busid].stream_len - g_usbd_video[busid].stream_offset;
-
-    if (remain == 0) {
-        g_usbd_video[busid].stream_frameid ^= 1;
-        return true;
-    }
-
-    len = MIN(remain, (g_usbd_video[busid].probe.dwMaxPayloadTransferSize - g_usbd_video[busid].stream_headerlen) * g_usbd_video[busid].max_packets);
-
-    offset = 0;
-    while (len > 0) {
-        header = (struct video_payload_header *)&g_usbd_video[busid].ep_buffer[offset];
-        header->bHeaderLength = g_usbd_video[busid].stream_headerlen;
-        header->headerInfoUnion.bmheaderInfo = 0;
-        header->headerInfoUnion.headerInfoBits.endOfHeader = 1;
-        header->headerInfoUnion.headerInfoBits.endOfFrame = 0;
-        header->headerInfoUnion.headerInfoBits.frameIdentifier = g_usbd_video[busid].stream_frameid;
-
-        uint32_t len2 = MIN(len, g_usbd_video[busid].probe.dwMaxPayloadTransferSize - g_usbd_video[busid].stream_headerlen);
-
-        usb_memcpy(&g_usbd_video[busid].ep_buffer[offset + g_usbd_video[busid].stream_headerlen],
-                   &g_usbd_video[busid].stream_buf[g_usbd_video[busid].stream_offset],
-                   len2);
-
-        g_usbd_video[busid].stream_offset += len2;
-        len -= len2;
-        offset += (len2 + g_usbd_video[busid].stream_headerlen);
-
-        if (g_usbd_video[busid].stream_offset == g_usbd_video[busid].stream_len) {
-            header->headerInfoUnion.headerInfoBits.endOfFrame = 1;
+    if (g_usbd_video[busid].ep_buf1_ready && (g_usbd_video[busid].ep_buf_idx == 0)) {    /* callback: buf1 ready and buf0 was sent */
+        g_usbd_video[busid].ep_buf0_ready = false;
+        g_usbd_video[busid].ep_buf_idx = 1;
+        usbd_ep_start_write(busid, ep, g_usbd_video[busid].ep_buf1, g_usbd_video[busid].ep_buf1_len);
+    } else if (g_usbd_video[busid].ep_buf0_ready && (g_usbd_video[busid].ep_buf_idx == 1)) {    /* callback: buf0 ready and buf1 was sent */
+        g_usbd_video[busid].ep_buf1_ready = false;
+        g_usbd_video[busid].ep_buf_idx = 0;
+        usbd_ep_start_write(busid, ep, g_usbd_video[busid].ep_buf0, g_usbd_video[busid].ep_buf0_len);
+    } else {
+        if (g_usbd_video[busid].stream_finish) {
+            return true;
         }
     }
 
-    usbd_ep_start_write(busid, ep, g_usbd_video[busid].ep_buffer, offset);
+    if (!g_usbd_video[busid].ep_buf0_ready) {
+        remain = g_usbd_video[busid].stream_len - g_usbd_video[busid].stream_offset;
+        if (remain == 0) {
+            g_usbd_video[busid].stream_frameid ^= 1;
+            g_usbd_video[busid].stream_finish = true;
+        } else {
+            g_usbd_video[busid].ep_buf0_len = usbd_video_prepare_ep_buf_data(busid, remain, g_usbd_video[busid].ep_buf0);
+            g_usbd_video[busid].ep_buf0_ready = true;
+            if (!g_usbd_video[busid].ep_buf1_ready) {
+                g_usbd_video[busid].ep_buf_idx = 0;
+                usbd_ep_start_write(busid, ep, g_usbd_video[busid].ep_buf0, g_usbd_video[busid].ep_buf0_len);
+            }
+        }
+    }
+
+    if (!g_usbd_video[busid].ep_buf1_ready) {
+        remain = g_usbd_video[busid].stream_len - g_usbd_video[busid].stream_offset;
+        if (remain == 0) {
+            g_usbd_video[busid].stream_frameid ^= 1;
+            g_usbd_video[busid].stream_finish = true;
+        } else {
+            g_usbd_video[busid].ep_buf1_len = usbd_video_prepare_ep_buf_data(busid, remain, g_usbd_video[busid].ep_buf1);
+            g_usbd_video[busid].ep_buf1_ready = true;
+        }
+    }
+
     return false;
 }
 
-int usbd_video_stream_start_write(uint8_t busid, uint8_t ep, uint8_t *ep_buffer, uint32_t ep_bufsize, uint8_t *stream_buf, uint32_t stream_len)
+int usbd_video_stream_start_write(uint8_t busid, uint8_t ep, uint8_t *ep_buf0, uint8_t *ep_buf1, uint32_t ep_bufsize, uint8_t *stream_buf, uint32_t stream_len)
 {
-    if (usb_device_is_configured(busid) == 0) {
+    if ((usb_device_is_configured(busid) == 0) || (stream_len == 0)) {
         return -1;
     }
 
-    g_usbd_video[busid].ep_buffer = ep_buffer;
+    g_usbd_video[busid].ep_buf0 = ep_buf0;
+    g_usbd_video[busid].ep_buf1 = ep_buf1;
+    g_usbd_video[busid].ep_buf0_ready = false;
+    g_usbd_video[busid].ep_buf1_ready = false;
+    g_usbd_video[busid].ep_buf_idx = 0;
+    g_usbd_video[busid].stream_finish = false;
     g_usbd_video[busid].max_packets = ep_bufsize / g_usbd_video[busid].probe.dwMaxPayloadTransferSize;
     g_usbd_video[busid].stream_buf = stream_buf;
     g_usbd_video[busid].stream_len = stream_len;

--- a/class/video/usbd_video.h
+++ b/class/video/usbd_video.h
@@ -22,7 +22,7 @@ void usbd_video_open(uint8_t busid, uint8_t intf);
 void usbd_video_close(uint8_t busid, uint8_t intf);
 
 bool usbd_video_stream_split_transfer(uint8_t busid, uint8_t ep);
-int usbd_video_stream_start_write(uint8_t busid, uint8_t ep, uint8_t *ep_buffer, uint32_t ep_bufsize, uint8_t *stream_buf, uint32_t stream_len);
+int usbd_video_stream_start_write(uint8_t busid, uint8_t ep, uint8_t *ep_buf0, uint8_t *ep_buf1, uint32_t ep_bufsize, uint8_t *stream_buf, uint32_t stream_len);
 
 #ifdef __cplusplus
 }

--- a/demo/video_audiov1_hid_template.c
+++ b/demo/video_audiov1_hid_template.c
@@ -269,7 +269,7 @@ static const uint8_t hid_keyboard_report_desc[HID_KEYBOARD_REPORT_DESC_SIZE] = {
 
 USB_NOCACHE_RAM_SECTION USB_MEM_ALIGNX uint8_t audio_read_buffer[AUDIO_OUT_PACKET];
 USB_NOCACHE_RAM_SECTION USB_MEM_ALIGNX uint8_t audio_write_buffer[AUDIO_IN_PACKET];
-USB_NOCACHE_RAM_SECTION USB_MEM_ALIGNX uint8_t video_packet_buffer[MAX_PACKETS_IN_ONE_TRANSFER * MAX_PAYLOAD_SIZE];
+USB_NOCACHE_RAM_SECTION USB_MEM_ALIGNX uint8_t video_packet_buffer[2][MAX_PACKETS_IN_ONE_TRANSFER * MAX_PAYLOAD_SIZE];
 
 volatile bool video_tx_flag = 0;
 volatile bool audio_tx_flag = 0;
@@ -480,7 +480,7 @@ void video_test(uint8_t busid)
     while (1) {
         if (video_tx_flag) {
             video_iso_tx_busy = true;
-            usbd_video_stream_start_write(busid, VIDEO_IN_EP, video_packet_buffer, MAX_PACKETS_IN_ONE_TRANSFER * MAX_PAYLOAD_SIZE, (uint8_t *)cherryusb_mjpeg, sizeof(cherryusb_mjpeg));
+            usbd_video_stream_start_write(busid, VIDEO_IN_EP, &video_packet_buffer[0][0], &video_packet_buffer[1][0], MAX_PACKETS_IN_ONE_TRANSFER * MAX_PAYLOAD_SIZE, (uint8_t *)cherryusb_mjpeg, sizeof(cherryusb_mjpeg));
             while (video_iso_tx_busy) {
                 if (video_tx_flag == 0) {
                     break;

--- a/demo/video_static_h264_template.c
+++ b/demo/video_static_h264_template.c
@@ -206,7 +206,7 @@ void video_init(uint8_t busid, uintptr_t reg_base)
     usbd_initialize(busid, reg_base, usbd_event_handler);
 }
 
-USB_NOCACHE_RAM_SECTION USB_MEM_ALIGNX uint8_t packet_buffer[40 * 1024];
+USB_NOCACHE_RAM_SECTION USB_MEM_ALIGNX uint8_t packet_buffer[2][40 * 1024];
 
 void video_test(uint8_t busid)
 {
@@ -214,11 +214,11 @@ void video_test(uint8_t busid)
     uint32_t packets;
 
     (void)packets;
-    memset(packet_buffer, 0, 40 * 1024);
+    memset(packet_buffer, 0, sizeof(packet_buffer));
     while (1) {
         if (tx_flag) {
             iso_tx_busy = true;
-            usbd_video_stream_start_write(busid, VIDEO_IN_EP, packet_buffer, MAX_PACKETS_IN_ONE_TRANSFER * MAX_PAYLOAD_SIZE, (uint8_t *)cherryusb_h264, sizeof(cherryusb_h264));
+            usbd_video_stream_start_write(busid, VIDEO_IN_EP, &packet_buffer[0][0], &packet_buffer[1][0], MAX_PACKETS_IN_ONE_TRANSFER * MAX_PAYLOAD_SIZE, (uint8_t *)cherryusb_h264, sizeof(cherryusb_h264));
             while (iso_tx_busy) {
                 if (tx_flag == 0) {
                     break;

--- a/demo/video_static_mjpeg_template.c
+++ b/demo/video_static_mjpeg_template.c
@@ -206,7 +206,7 @@ void video_init(uint8_t busid, uintptr_t reg_base)
     usbd_initialize(busid, reg_base, usbd_event_handler);
 }
 
-USB_NOCACHE_RAM_SECTION USB_MEM_ALIGNX uint8_t packet_buffer[MAX_PACKETS_IN_ONE_TRANSFER * MAX_PAYLOAD_SIZE];
+USB_NOCACHE_RAM_SECTION USB_MEM_ALIGNX uint8_t packet_buffer[2][MAX_PACKETS_IN_ONE_TRANSFER * MAX_PAYLOAD_SIZE];
 
 void video_test(uint8_t busid)
 {
@@ -215,7 +215,7 @@ void video_test(uint8_t busid)
     while (1) {
         if (tx_flag) {
             iso_tx_busy = true;
-            usbd_video_stream_start_write(busid, VIDEO_IN_EP, packet_buffer, MAX_PACKETS_IN_ONE_TRANSFER * MAX_PAYLOAD_SIZE, (uint8_t *)cherryusb_mjpeg, sizeof(cherryusb_mjpeg));
+            usbd_video_stream_start_write(busid, VIDEO_IN_EP, &packet_buffer[0][0], &packet_buffer[1][0], MAX_PACKETS_IN_ONE_TRANSFER * MAX_PAYLOAD_SIZE, (uint8_t *)cherryusb_mjpeg, sizeof(cherryusb_mjpeg));
             while (iso_tx_busy) {
                 if (tx_flag == 0) {
                     break;

--- a/demo/video_static_yuyv_template.c
+++ b/demo/video_static_yuyv_template.c
@@ -208,7 +208,7 @@ void video_init(uint8_t busid, uintptr_t reg_base)
     usbd_initialize(busid, reg_base, usbd_event_handler);
 }
 
-USB_NOCACHE_RAM_SECTION USB_MEM_ALIGNX uint8_t packet_buffer[MAX_PACKETS_IN_ONE_TRANSFER * MAX_PAYLOAD_SIZE];
+USB_NOCACHE_RAM_SECTION USB_MEM_ALIGNX uint8_t packet_buffer[2][MAX_PACKETS_IN_ONE_TRANSFER * MAX_PAYLOAD_SIZE];
 
 void video_test(uint8_t busid)
 {
@@ -217,7 +217,7 @@ void video_test(uint8_t busid)
     while (1) {
         if (tx_flag) {
             iso_tx_busy = true;
-            usbd_video_stream_start_write(busid, VIDEO_IN_EP, packet_buffer, MAX_PACKETS_IN_ONE_TRANSFER * MAX_PAYLOAD_SIZE, (uint8_t *)cherryusb_yuyv, sizeof(cherryusb_yuyv));
+            usbd_video_stream_start_write(busid, VIDEO_IN_EP, &packet_buffer[0][0], &packet_buffer[1][0], MAX_PACKETS_IN_ONE_TRANSFER * MAX_PAYLOAD_SIZE, (uint8_t *)cherryusb_yuyv, sizeof(cherryusb_yuyv));
             while (iso_tx_busy) {
                 if (tx_flag == 0) {
                     break;


### PR DESCRIPTION
- use pingpang buffer to improve tx performance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Implemented a dual-buffer mechanism for video streaming, improving data handling efficiency.
  
- **Bug Fixes**
	- Enhanced control flow for video transmission by ensuring proper management of multiple video packets.
  
- **Documentation**
	- Updated function signatures and variable declarations to reflect changes in buffer handling for video streaming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->