### PR TITLE
修复VID/PID匹配逻辑

### DIFF
--- a/core/usbh_core.c
+++ b/core/usbh_core.c
@@ -105,7 +105,10 @@ static const struct usbh_class_driver *usbh_find_class_driver(uint8_t class, uin
         if (index->match_flags & USB_CLASS_MATCH_VID_PID && index->id_table) {
             /* scan id table */
             uint32_t i;
-            for (i = 0; index->id_table[i][0] && index->id_table[i][0] != vid && index->id_table[i][1] != pid; i++) {
+            for (i = 0; index->id_table[i][0]; i++) {
+                if (index->id_table[i][0] == vid && index->id_table[i][1] == pid) {
+                    break;
+                }
             }
             /* do not match, continue next */
             if (!index->id_table[i][0]) {


### PR DESCRIPTION
原来逻辑是匹配VID或者PID即返回，应该需要同时匹配吧？

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling for freeing device addresses.
  
- **Refactor**
	- Simplified logic for matching USB device IDs, enhancing clarity and potential performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->