### PR TITLE
UVC frame completes flag

### DIFF
--- a/class/video/usbd_video.c
+++ b/class/video/usbd_video.c
@@ -879,6 +879,5 @@ int usbd_video_stream_start_write(uint8_t busid, uint8_t ep, uint8_t *ep_buf0, u
     g_usbd_video[busid].stream_len = stream_len;
     g_usbd_video[busid].stream_offset = 0;
 
-    usbd_video_stream_split_transfer(busid, ep);
-    return 0;
+    return usbd_video_stream_split_transfer(busid, ep);
 }


### PR DESCRIPTION
The frame completion flag is returned when the usbd_video_stream_start_write function completes a frame transfer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved status reporting for video streaming operations, allowing more accurate feedback on success or completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->