### PR TITLE
msc: add support for SCSI_CMD_SYNCHCACHE10 (0x35) to fix unsupported …

### DIFF
--- a/class/msc/usbd_msc.c
+++ b/class/msc/usbd_msc.c
@@ -807,7 +807,9 @@ static bool SCSI_CBWDecode(uint8_t busid, uint32_t nbytes)
                 //ret = SCSI_verify10(NULL, 0);
                 ret = false;
                 break;
-
+            case SCSI_CMD_SYNCHCACHE10:
+                ret = true;
+                break;
             default:
                 SCSI_SetSenseData(busid, SCSI_KCQIR_INVALIDCOMMAND);
                 USB_LOG_WRN("unsupported cmd:0x%02x\r\n", g_usbd_msc[busid].cbw.CB[0]);


### PR DESCRIPTION
Some hosts (e.g. Windows) may issue SCSI_CMD_SYNCHCACHE10 (0x35) to flush write caches.
Without handling this command, CherryUSB MSC would log "unsupported cmd:0x35" and set 
sense data to INVALIDCOMMAND. This patch adds a simple response to SCSI_CMD_SYNCHCACHE10 
to improve host compatibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of the SCSI SYNC CACHE (10) command to prevent unnecessary error responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->