### PR TITLE
Bugfix: There is a QTD memory block leak in the ehci_control_urb_init function

### DIFF
--- a/port/ehci/usb_hc_ehci.c
+++ b/port/ehci/usb_hc_ehci.c
@@ -336,10 +336,8 @@ static struct ehci_qh_hw *ehci_control_urb_init(struct usbh_bus *bus, struct usb
     }
 
     qtd_setup = ehci_qtd_alloc(bus);
-    qtd_data = ehci_qtd_alloc(bus);
     qtd_status = ehci_qtd_alloc(bus);
-
-    USB_ASSERT_MSG(qtd_setup && qtd_data && qtd_status, "ctrl qtd alloc failed");
+    USB_ASSERT_MSG(qtd_setup && qtd_status, "ctrl qtd alloc failed");
 
     ehci_qh_fill(qh,
                  urb->hport->dev_addr,
@@ -363,6 +361,9 @@ static struct ehci_qh_hw *ehci_control_urb_init(struct usbh_bus *bus, struct usb
 
     /* fill data qtd */
     if (setup->wLength > 0) {
+        qtd_data = ehci_qtd_alloc(bus);
+        USB_ASSERT_MSG(qtd_data, "ctrl qtd alloc failed");
+
         if ((setup->bmRequestType & 0x80) == 0x80) {
             token = QTD_TOKEN_PID_IN;
         } else {


### PR DESCRIPTION
In the ehci_control_urb_init function, if the control transfer has no data stage, it will cause the QTD memory block to leak

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of data transfers by allocating resources for data packets only when necessary, enhancing reliability and efficiency during USB control transfers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->