### PR TITLE
Update WINUSB and WebUSB related logic to better adhere to standard

### DIFF
--- a/core/usbd_core.h
+++ b/core/usbd_core.h
@@ -78,6 +78,7 @@ struct usb_descriptor {
     const uint8_t *(*device_quality_descriptor_callback)(uint8_t speed);
     const uint8_t *(*other_speed_descriptor_callback)(uint8_t speed);
     const char *(*string_descriptor_callback)(uint8_t speed, uint8_t index);
+    void (*ep0_vendor_in_cmp_callback)(uint8_t busid);
     const struct usb_msosv1_descriptor *msosv1_descriptor;
     const struct usb_msosv2_descriptor *msosv2_descriptor;
     const struct usb_webusb_descriptor *webusb_url_descriptor;


### PR DESCRIPTION
In current CherryUSB implementation, If bmRequestType[Bits 5:6: Request type] matches USB_REQUEST_VENDOR, CherryUSB would check if it match WINUSB or WebUSB.
The bmRequestType[Bits 0:4: Recipient] if not checked, but the stamdard says it should be USB_REQUEST_RECIPIENT_DEVICE.

Not checking this would result in incorrect handling of some vendor requests as WinUSB or WebUSB request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of vendor requests to ensure only device-specific requests are processed, enhancing USB request reliability and security.
  * Enhanced USB vendor IN transfer completion tracking with new callbacks for better device communication feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->