### PR TITLE
bugfix: Fix support for idf versions lower than 5.3

### DIFF
--- a/osal/idf/usb_config.h
+++ b/osal/idf/usb_config.h
@@ -28,7 +28,12 @@
 
 // #define CONFIG_USB_DCACHE_ENABLE
 
-/* attribute data into no cache ram */
+/* attribute data into no cache ram 
+* DRAM_DMA_ALIGNED_ATTR was introduced in IDF 5.3. If not defined, it falls back to DMA_ATTR
+*/
+#ifndef DRAM_DMA_ALIGNED_ATTR
+#define DRAM_DMA_ALIGNED_ATTR DMA_ATTR
+#endif
 #define USB_NOCACHE_RAM_SECTION DRAM_DMA_ALIGNED_ATTR
 
 /* use usb_memcpy default for high performance but cost more flash memory.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved cross-version compatibility for USB memory attributes. The app now consistently applies the non-cacheable RAM attribute across different IDF versions, reducing build-time warnings/errors and ensuring stable DMA behavior on supported devices. This prevents regressions when upgrading or using older SDKs. No configuration changes are required for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->