### PR TITLE
Add library.json for PlatformIO library support

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,0 +1,42 @@
+{
+  "name": "CherryUSB",
+  "version": "1.5.2",
+  "description": "CherryUSB is a tiny and beautiful, high performace and portable USB host and device stack for embedded system with USB IP",
+  "keywords": "usb, host, device",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/cherry-embedded/CherryUSB.git"
+  },
+  "authors": [
+    {
+      "name": "sakumisu",
+      "maintainer": true
+    }
+  ],
+  "license": "Apache-2.0",
+  "homepage": "https://cherryusb.readthedocs.io/",
+  "frameworks": "*",
+  "platforms": "*",
+  "build": {
+    "flags": [
+      "-I common",
+      "-I core",
+      "-I class/hub",
+      "-I class/cdc",
+      "-I class/hid",
+      "-I class/msc",
+      "-I class/audio",
+      "-I class/video",
+      "-I class/wireless",
+      "-I class/midi",
+      "-I class/adb",
+      "-I class/dfu",
+      "-I class/vendor/net",
+      "-I class/vendor/serial",
+      "-I class/vendor/wifi",
+      "-I class/aoa"
+    ],
+    "srcDir": ".",
+    "srcFilter": "+<*> -<demo> -<docs> -<tools>"
+  }
+}


### PR DESCRIPTION
I would like to add support for PlatformIO library to CherryUSB. PlatformIO library requires `library.json` at the root of the library as metadata to install the package. You may find more information [here](https://docs.platformio.org/en/latest/manifests/library-json/index.html) and [here](https://docs.platformio.org/en/latest/librarymanager/creating.html). TinyUSB also has this JSON file. The unfortunate thing about this is we now have another place to bump the version number whenever we release a new CherryUSB version.

Please let me know if you have any concerns.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a package metadata manifest (package name CherryUSB, version 1.5.2) including description, keywords, repository, author/maintainer, license (Apache-2.0), homepage, frameworks/platforms, and build/include settings.
  * No changes to runtime behavior or public APIs; purely metadata for tooling and package management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->