### PR TITLE
docs(readme): unify badge style

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 <h1 align="center" style="margin: 30px 0 30px; font-weight: bold;">CherryUSB</h1>
 <p align="center">
 	<a href="https://github.com/cherry-embedded/CherryUSB/releases"><img src="https://img.shields.io/github/release/cherry-embedded/CherryUSB.svg"></a>
-	<a href="https://github.com/cherry-embedded/CherryUSB/blob/master/LICENSE"><img src="https://img.shields.io/github/license/cherry-embedded/CherryUSB.svg?style=flat-square"></a>
+	<a href="https://github.com/cherry-embedded/CherryUSB/blob/master/LICENSE"><img src="https://img.shields.io/github/license/cherry-embedded/CherryUSB.svg"></a>
     <a href="https://github.com/cherry-embedded/CherryUSB/actions/workflows/deploy-docs.yml"><img src="https://github.com/cherry-embedded/CherryUSB/actions/workflows/deploy-docs.yml/badge.svg"> </a>
-    <a href="https://discord.com/invite/wFfvrSAey8"><img src="https://img.shields.io/badge/Discord-blue?logo=discord&style=flat-square"> </a>
+    <a href="https://discord.com/invite/wFfvrSAey8"><img src="https://img.shields.io/badge/Discord-blue?logo=discord"> </a>
 </p>
 
 CherryUSB is a tiny and beautiful, high performance and portable USB host and device stack for embedded system with USB IP.


### PR DESCRIPTION
Fix some style inconsistency for readme badge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README badge formatting for improved visual consistency.
  * Removed explicit “flat-square” styling from License and Discord badges to use default styles.
  * No functional or behavioral changes to the application.
  * No API or public interface changes.
  * Low review effort expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->