### PR TITLE
Add isochronous transfer support to fsdev by configuring double-buffering for isochronous endpoints.

### DIFF
--- a/port/fsdev/usb_fsdev_reg.h
+++ b/port/fsdev/usb_fsdev_reg.h
@@ -1681,4 +1681,19 @@ typedef struct
 #define PCD_GET_EP_DBUF0_CNT(USBx, bEpNum)     (PCD_GET_EP_TX_CNT((USBx), (bEpNum)))
 #define PCD_GET_EP_DBUF1_CNT(USBx, bEpNum)     (PCD_GET_EP_RX_CNT((USBx), (bEpNum)))
 
+#define PCD_FREE_USER_BUFFER(USBx, bEpNum, bDir) \
+  do { \
+    if ((bDir) == 0U) \
+    { \
+      /* OUT double buffered endpoint */ \
+      PCD_TX_DTOG((USBx), (bEpNum)); \
+    } \
+    else if ((bDir) == 1U) \
+    { \
+      /* IN double buffered endpoint */ \
+      PCD_RX_DTOG((USBx), (bEpNum)); \
+    } \
+  } while(0)
+
+  
 #endif


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented ISOCHRONOUS USB endpoint support with dual-buffering capability for continuous, real-time data transfers
  * Added automatic buffer switching and intelligent management during endpoint operations

* **Refactor**
  * Enhanced endpoint initialization, closure, and interrupt-driven transfer handling for complex USB scenarios
  * Optimized write operations and data path management for improved USB device compatibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->