### PR TITLE
Fix host serial framework support for rt-thread

### DIFF
--- a/Kconfig.rttpkg
+++ b/Kconfig.rttpkg
@@ -314,6 +314,7 @@ if PKG_USING_CHERRYUSB
         config PKG_CHERRYUSB_HOST_CDC_ACM
             bool
             prompt "Enable usb cdc acm driver"
+            select CONFIG_USBHOST_SERIAL
             default n
 
         config PKG_CHERRYUSB_HOST_HID
@@ -464,7 +465,7 @@ if PKG_USING_CHERRYUSB
         menu "Select USB host template, please select class driver first"
             config CONFIG_TEST_USBH_SERIAL
                 int
-                prompt "demo for test usb serial, cannot enable this demo, we have used serial framework instead"
+                prompt "demo for test serial, cannot enable this demo, we have used serial framework instead"
                 default 0
                 depends on PKG_CHERRYUSB_HOST_CDC_ACM || PKG_CHERRYUSB_HOST_FTDI || PKG_CHERRYUSB_HOST_CH34X || PKG_CHERRYUSB_HOST_CP210X || PKG_CHERRYUSB_HOST_PL2303
             config CONFIG_TEST_USBH_HID

--- a/SConscript
+++ b/SConscript
@@ -16,7 +16,6 @@ path += [cwd + '/class/adb']
 path += [cwd + '/class/dfu']
 path += [cwd + '/class/serial']
 path += [cwd + '/class/vendor/net']
-path += [cwd + '/class/vendor/serial']
 path += [cwd + '/class/vendor/wifi']
 src = []
 
@@ -269,7 +268,7 @@ if GetDepend(['PKG_CHERRYUSB_HOST']):
             LIBS = ['libxhci_a32_softfp_neon.a']
 
     if GetDepend(['PKG_CHERRYUSB_HOST_CDC_ACM']):
-        src += Glob('class/cdc/usbh_cdc_acm.c')
+        src += Glob('class/serial/usbh_cdc_acm.c')
     if GetDepend(['PKG_CHERRYUSB_HOST_HID']):
         src += Glob('class/hid/usbh_hid.c')
     if GetDepend(['PKG_CHERRYUSB_HOST_MSC']):
@@ -291,13 +290,13 @@ if GetDepend(['PKG_CHERRYUSB_HOST']):
     if GetDepend(['PKG_CHERRYUSB_HOST_RTL8152']):
         src += Glob('class/vendor/net/usbh_rtl8152.c')
     if GetDepend(['PKG_CHERRYUSB_HOST_FTDI']):
-        src += Glob('class/vendor/serial/usbh_ftdi.c')
+        src += Glob('class/serial/usbh_ftdi.c')
     if GetDepend(['PKG_CHERRYUSB_HOST_CH34X']):
-        src += Glob('class/vendor/serial/usbh_ch34x.c')
+        src += Glob('class/serial/usbh_ch34x.c')
     if GetDepend(['PKG_CHERRYUSB_HOST_CP210X']):
-        src += Glob('class/vendor/serial/usbh_cp210x.c')
+        src += Glob('class/serial/usbh_cp210x.c')
     if GetDepend(['PKG_CHERRYUSB_HOST_PL2303']):
-        src += Glob('class/vendor/serial/usbh_pl2303.c')
+        src += Glob('class/serial/usbh_pl2303.c')
 
     if GetDepend(['CONFIG_TEST_USBH_HID']):
         src += Glob('demo/usb_host.c')

--- a/class/serial/usbh_serial.c
+++ b/class/serial/usbh_serial.c
@@ -389,7 +389,7 @@ static int usbh_serial_tiocmset(struct usbh_serial *serial, uint32_t set, uint32
         line_state &= ~USBH_SERIAL_TIOCM_RTS;
     }
 
-    dtr = (line_state & USBH_SERIAL_TIOCM_RTS) ? true : false;
+    dtr = (line_state & USBH_SERIAL_TIOCM_DTR) ? true : false;
     rts = (line_state & USBH_SERIAL_TIOCM_RTS) ? true : false;
 
     if (serial && serial->driver && serial->driver->set_line_state) {
@@ -641,6 +641,12 @@ int usbh_serial(int argc, char **argv)
     if (argc < 3) {
         usbh_serial_help();
         return 0;
+    }
+
+    if (serial) {
+        if (!serial->hport || !serial->hport->connected) {
+            serial = NULL;
+        }
     }
 
     if (!serial) {

--- a/platform/rtthread/usbh_rtserial.c
+++ b/platform/rtthread/usbh_rtserial.c
@@ -176,8 +176,14 @@ rt_err_t usbh_serial_register(struct usbh_serial *serial)
     device->user_data = serial;
     serial->user_data = device;
 
+    /* skip /dev/ to avoid BAD file */
+    const char *dev_name = serial->hport->config.intf[serial->intf].devname;
+    if (strncmp(dev_name, "/dev/", 5) == 0) {
+        dev_name += 5;
+    }
+
     /* register a character device */
-    ret = rt_device_register(device, serial->hport->config.intf[serial->intf].devname, RT_DEVICE_FLAG_RDWR | RT_DEVICE_FLAG_INT_RX | RT_DEVICE_FLAG_REMOVABLE);
+    ret = rt_device_register(device, dev_name, RT_DEVICE_FLAG_RDWR | RT_DEVICE_FLAG_INT_RX | RT_DEVICE_FLAG_REMOVABLE);
 
 #ifdef RT_USING_POSIX_DEVIO
     /* set fops */


### PR DESCRIPTION
This PR includes the following fixes:
- Fix scons path
- Fix dtr flag in CLI handling
- Fix device register in rtt with correct name

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed DTR line-state handling and improved device reuse so disconnected ports reopen reliably.

* **Chores**
  * Reorganized USB driver lookup paths in build config.
  * Strip leading "/dev/" from device names during registration for consistent naming.
  * Added a dependency for the CDC ACM host driver.
  * Updated config prompt text for the USB serial test demo.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->