### PR TITLE
Add HS support for esp32s31

### DIFF
--- a/idf_component.yml
+++ b/idf_component.yml
@@ -23,3 +23,4 @@ targets:
   - esp32s2
   - esp32s3
   - esp32p4
+  - esp32s31

--- a/osal/idf/usb_config.h
+++ b/osal/idf/usb_config.h
@@ -266,6 +266,13 @@
 #define CONFIG_USBDEV_MAX_BUS 2
 #define CONFIG_USBHOST_MAX_BUS 2
 #define CONFIG_USB_HS
+#elif CONFIG_IDF_TARGET_ESP32S31
+#define ESP_USB_HS0_BASE            0x20300000
+#define ESP_USBD_BASE               ESP_USB_HS0_BASE
+#define ESP_USBH_BASE               ESP_USB_HS0_BASE
+#define CONFIG_USBDEV_MAX_BUS 1
+#define CONFIG_USBHOST_MAX_BUS 1
+#define CONFIG_USB_HS
 #else
 #error "Unsupported SoC"
 #endif

--- a/port/dwc2/README.md
+++ b/port/dwc2/README.md
@@ -36,7 +36,7 @@ Please note that host must support dma mode.
 
 ### Espressif
 
-- ESP32S2、ESP32S3、ESP32P4
+- ESP32S2、ESP32S3、ESP32P4、ESP32S31
 
 ### Sophgo
 

--- a/port/dwc2/usb_glue_esp.c
+++ b/port/dwc2/usb_glue_esp.c
@@ -36,6 +36,15 @@
 #define GET_USB_PHY_TARGET(reg_base)    ((reg_base) == (void*)ESP_USB_HS0_BASE ? USB_PHY_TARGET_UTMI : USB_PHY_TARGET_INT)
 #undef GET_USB_PHY_SPEED
 #define GET_USB_PHY_SPEED(reg_base)    ((reg_base) == (void*)ESP_USB_HS0_BASE ? USB_PHY_SPEED_HIGH : USB_PHY_SPEED_FULL)
+#elif CONFIG_IDF_TARGET_ESP32S31
+#define DEFAULT_CPU_FREQ_MHZ    CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ
+#define DEFAULT_USB_INTR_SOURCE ETS_USB_OTGHS_INTR_SOURCE
+#undef GET_USB_INTR_SOURCE
+#define GET_USB_INTR_SOURCE(reg_base)   DEFAULT_USB_INTR_SOURCE
+#undef GET_USB_PHY_TARGET
+#define GET_USB_PHY_TARGET(reg_base)    USB_PHY_TARGET_UTMI
+#undef GET_USB_PHY_SPEED
+#define GET_USB_PHY_SPEED(reg_base)     USB_PHY_SPEED_HIGH
 #else
 #define DEFAULT_CPU_FREQ_MHZ 160
 #endif
@@ -72,6 +81,35 @@ const struct dwc2_user_params param_fs = {
     .host_rx_fifo_size = 80,
     .host_nperio_tx_fifo_size = 60, // 240 byte
     .host_perio_tx_fifo_size = 60,  // 240 byte
+};
+#elif CONFIG_IDF_TARGET_ESP32S31
+const struct dwc2_user_params param_hs = {
+    .phy_type = DWC2_PHY_TYPE_PARAM_UTMI,
+    .device_dma_enable = true,
+    .device_dma_desc_enable = false,
+    .device_rx_fifo_size = (896 - 16 - 128 - 128 - 128 - 128 - 16 - 16),
+    .device_tx_fifo_size = {
+        [0] = 16,  // 64 byte
+        [1] = 128, // 512 byte
+        [2] = 128, // 512 byte
+        [3] = 128, // 512 byte
+        [4] = 128, // 512 byte
+        [5] = 16,  // 64 byte
+        [6] = 16,  // 64 byte
+        [7] = 0,
+        [8] = 0,
+        [9] = 0,
+        [10] = 0,
+        [11] = 0,
+        [12] = 0,
+        [13] = 0,
+        [14] = 0,
+        [15] = 0 },
+
+    .host_dma_desc_enable = false,
+    .host_rx_fifo_size = (896 - 128 - 128),
+    .host_nperio_tx_fifo_size = 128, // 512 byte
+    .host_perio_tx_fifo_size = 128,  // 512 byte
 };
 #elif CONFIG_IDF_TARGET_ESP32P4
 const struct dwc2_user_params param_fs = {
@@ -243,6 +281,8 @@ void dwc2_get_user_params(uint32_t reg_base, struct dwc2_user_params *params)
     } else {
         memcpy(params, &param_fs, sizeof(struct dwc2_user_params));
     }
+#elif CONFIG_IDF_TARGET_ESP32S31
+    memcpy(params, &param_hs, sizeof(struct dwc2_user_params));
 #endif
 #ifdef CONFIG_USB_DWC2_CUSTOM_FIFO
     struct usb_dwc2_user_fifo_config s_dwc2_fifo_config;


### PR DESCRIPTION

## Basic Information
| Configuration Item                             | Value of S31 | Basis                    |
|------------------------------------------------|--------------|--------------------------|
| CONFIG_USBDEV_MAX_BUS / CONFIG_USBHOST_MAX_BUS | 1 | [SOC_USB_OTG_PERIPH_NUM=1](https://github.com/espressif/esp-idf/blob/master/components/soc/esp32s31/include/soc/soc_caps.h#L116C9-L116C31) |
| ESP_USB_HS0_BASE | 0x20300000 |[DR_REG_USB_OTGHS_BASE=0x20300000](https://github.com/espressif/esp-idf/blob/master/components/soc/esp32s31/register/soc/reg_base.h#L8)|
| DEFAULT_USB_INTR_SOURCE | ETS_USB_OTGHS_INTR_SOURCE |[ETS_USB_OTGHS_INTR_SOURCE](https://github.com/espressif/esp-idf/blob/master/components/soc/esp32s31/include/soc/interrupts.h#L118)|
|PHY target|USB_PHY_TARGET_UTMI|[SOC_USB_UTMI_PHY_NUM=1](https://github.com/espressif/esp-idf/blob/master/components/soc/esp32s31/include/soc/soc_caps.h#L118C9-L118C29)|

## Basic Test

The ESP32S31 currently only supports building on **[ESP-IDF Master](https://github.com/espressif/esp-idf)**.

### cdc_acm_msc_template

<img width="1423" height="404" alt="image" src="https://github.com/user-attachments/assets/fbff472f-0a0e-4ed5-9b19-f5975ba70e80" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for ESP32S31 microcontroller platform
  * Enabled USB device and host functionality for ESP32S31
  * Configured high-speed USB operations for the new target

* **Documentation**
  * Updated supported platforms documentation to include ESP32S31

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cherry-embedded/CherryUSB/pull/416)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->