### PR TITLE
fix: add buffer-length check in rt_usbh_lwip.c

### DIFF
--- a/platform/rtthread/rt_usbh_lwip.c
+++ b/platform/rtthread/rt_usbh_lwip.c
@@ -76,6 +76,10 @@ void usbh_lwip_eth_output_common(struct pbuf *p, uint8_t *buf)
 
 void usbh_lwip_eth_input_common(struct netif *netif, uint8_t *buf, uint32_t len)
 {
+    if (len > 1514) {
+        USB_LOG_ERR("Ethernet frame too large: %" PRIu32 "\r\n", len);
+        return;
+    }
 #if LWIP_TCPIP_CORE_LOCKING_INPUT
     pbuf_type type = PBUF_REF;
 #else


### PR DESCRIPTION
## Summary
Fix critical severity security issue in `platform/rtthread/rt_usbh_lwip.c`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-003 |
| **Severity** | CRITICAL |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-003` |
| **File** | `platform/rtthread/rt_usbh_lwip.c:144` |
| **CWE** | CWE-120 |

**Description**: The usbh_cdc_ecm_eth_input function at rt_usbh_lwip.c:144 accepts a raw buffer and its length from a USB CDC-ECM device. The buflen parameter is not validated against the maximum expected Ethernet frame size (1514 bytes for standard frames, 9000 bytes for jumbo frames) before the buffer is processed and passed to netif->input(). A malicious USB CDC-ECM device can supply an oversized frame, causing a buffer overflow in the lwIP network stack processing path and corrupting adjacent memory.

## Changes
- `platform/rtthread/rt_usbh_lwip.c`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to reject Ethernet frames exceeding 1514 bytes, preventing potential processing errors and improving system stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cherry-embedded/CherryUSB/pull/417?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->