### PR TITLE
fix(usbh): bounds-check cur_ep before writing ep[] in parse_config_descriptor

### DIFF
--- a/core/usbh_core.c
+++ b/core/usbh_core.c
@@ -272,6 +272,12 @@ static int parse_config_descriptor(struct usbh_hubport *hport, struct usb_config
                         return -USB_ERR_INVAL;
                     }
                     ep_desc = (struct usb_endpoint_descriptor *)p;
+
+                    if (cur_ep >= CONFIG_USBHOST_MAX_ENDPOINTS) {
+                        USB_LOG_ERR("Endpoint num %d overflow\r\n", cur_ep);
+                        return -USB_ERR_NOMEM;
+                    }
+
                     memcpy(&hport->config.intf[cur_iface].altsetting[cur_alt_setting].ep[cur_ep].ep_desc, ep_desc, 7);
                     cur_ep++;
                     break;

--- a/core/usbh_core.c
+++ b/core/usbh_core.c
@@ -242,7 +242,7 @@ static int parse_config_descriptor(struct usbh_hubport *hport, struct usb_config
                         return -USB_ERR_NOMEM;
                     }
 
-                    if (cur_ep_num >= CONFIG_USBHOST_MAX_ENDPOINTS) {
+                    if (cur_ep_num > CONFIG_USBHOST_MAX_ENDPOINTS) {
                         USB_LOG_ERR("Endpoint num %d overflow\r\n", cur_ep_num);
                         return -USB_ERR_NOMEM;
                     }


### PR DESCRIPTION
parse_config_descriptor() checks cur_ep_num (the interface descriptor's self-declared bNumEndpoints) against CONFIG_USBHOST_MAX_ENDPOINTS when the INTERFACE descriptor is parsed, but cur_ep (the actual write index, incremented once per ENDPOINT sub-descriptor encountered in the byte stream) is never bounds-checked in the USB_DESCRIPTOR_TYPE_ENDPOINT case before the memcpy.

A non-conformant or malicious device can declare a small bNumEndpoints while still emitting more ENDPOINT descriptors than declared in the raw config descriptor byte stream (both wTotalLength and the descriptor bytes come directly from the device's GET_DESCRIPTOR response during enumeration). This causes cur_ep to exceed CONFIG_USBHOST_MAX_ENDPOINTS and the memcpy to write past the ep[] array, past altsetting[], and potentially past the whole usbh_configuration struct.

This adds the same bounds check pattern already used for cur_iface and cur_alt_setting two cases above, applied to cur_ep before the memcpy.

Verified with a standalone harness reproducing the real struct layout and parse_config_descriptor() logic verbatim: a crafted config descriptor with bNumEndpoints=1 followed by 6 ENDPOINT sub-descriptors corrupts the adjacent altsetting slot without this check (ep[4]/ep[5] write lands exactly in altsetting[1]), and a variant targeting the last interface/altsetting slot corrupts memory past the whole usbh_configuration struct. With the fix, parse_config_descriptor() correctly returns -USB_ERR_NOMEM once cur_ep reaches CONFIG_USBHOST_MAX_ENDPOINTS, the first CONFIG_USBHOST_MAX_ENDPOINTS legitimate endpoints still parse correctly, and no out-of-bounds memory is touched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved USB configuration descriptor parsing to more precisely detect when the maximum endpoint limit is exceeded.
  * Added safer bounds validation so invalid/overflowing endpoint information is no longer written during parsing; parsing now stops cleanly and returns an error when limits are hit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->