### PR TITLE
adb: fix off-by-one OOB write when null-terminating A_OPEN payload

### DIFF
--- a/class/adb/usbd_adb.c
+++ b/class/adb/usbd_adb.c
@@ -161,7 +161,13 @@ void usbd_adb_bulk_out(uint8_t busid, uint8_t ep, uint32_t nbytes)
                 adb_client.writable = false;
             } break;
             case A_OPEN: /* OPEN(local-id, 0, "destination") */
-                rx_packet.payload[rx_packet.msg.data_length] = '\0';
+                /* data_length may equal sizeof(payload); writing at [data_length]
+                 * would be one past the end of the buffer. */
+                if (rx_packet.msg.data_length >= sizeof(rx_packet.payload)) {
+                    rx_packet.payload[sizeof(rx_packet.payload) - 1] = '\0';
+                } else {
+                    rx_packet.payload[rx_packet.msg.data_length] = '\0';
+                }
 
                 if (strncmp((const char *)rx_packet.payload, "shell:", 6) == 0) {
                     adb_client.localid = ADB_SHELL_LOALID;

--- a/class/adb/usbd_adb.c
+++ b/class/adb/usbd_adb.c
@@ -115,7 +115,7 @@ void usbd_adb_bulk_out(uint8_t busid, uint8_t ep, uint32_t nbytes)
 
     if (adb_client.common_state == ADB_STATE_READ_MSG) {
         USB_ASSERT(nbytes == sizeof(struct adb_msg));
-        USB_ASSERT(rx_packet.msg.data_length <= sizeof(rx_packet.payload));
+        USB_ASSERT(rx_packet.msg.data_length < sizeof(rx_packet.payload));
 
         USB_LOG_DBG("command:%x arg0:%x arg1:%x len:%d\r\n",
                     rx_packet.msg.command,

--- a/class/adb/usbd_adb.c
+++ b/class/adb/usbd_adb.c
@@ -115,7 +115,10 @@ void usbd_adb_bulk_out(uint8_t busid, uint8_t ep, uint32_t nbytes)
 
     if (adb_client.common_state == ADB_STATE_READ_MSG) {
         USB_ASSERT(nbytes == sizeof(struct adb_msg));
-        USB_ASSERT(rx_packet.msg.data_length < sizeof(rx_packet.payload));
+        USB_ASSERT(rx_packet.msg.data_length <= sizeof(rx_packet.payload));
+        if (rx_packet.msg.command == A_OPEN) {
+            USB_ASSERT(rx_packet.msg.data_length < sizeof(rx_packet.payload));
+        }
 
         USB_LOG_DBG("command:%x arg0:%x arg1:%x len:%d\r\n",
                     rx_packet.msg.command,

--- a/class/adb/usbd_adb.c
+++ b/class/adb/usbd_adb.c
@@ -161,13 +161,7 @@ void usbd_adb_bulk_out(uint8_t busid, uint8_t ep, uint32_t nbytes)
                 adb_client.writable = false;
             } break;
             case A_OPEN: /* OPEN(local-id, 0, "destination") */
-                /* data_length may equal sizeof(payload); writing at [data_length]
-                 * would be one past the end of the buffer. */
-                if (rx_packet.msg.data_length >= sizeof(rx_packet.payload)) {
-                    rx_packet.payload[sizeof(rx_packet.payload) - 1] = '\0';
-                } else {
-                    rx_packet.payload[rx_packet.msg.data_length] = '\0';
-                }
+                rx_packet.payload[rx_packet.msg.data_length] = '\0';
 
                 if (strncmp((const char *)rx_packet.payload, "shell:", 6) == 0) {
                     adb_client.localid = ADB_SHELL_LOALID;


### PR DESCRIPTION
In `usbd_adb_bulk_out()`, the A_OPEN handler null-terminates the incoming payload so it can be treated as a C string:

```c
rx_packet.payload[rx_packet.msg.data_length] = '\0';
```

`payload` is a fixed-size buffer and the assert right above this line only checks `data_length <= sizeof(payload)`, so a `data_length` that's exactly equal to the buffer size passes as "valid". When that happens, the write lands one byte past the end of the array, into whatever memory follows the `rx_packet` global. Since `data_length` comes straight from the host over the wire, any ADB host that opens a stream with the maximum allowed payload length hits this on every A_OPEN.

Fix is just to stop writing past the last valid index: if `data_length` is at (or somehow past) the buffer size, terminate at the last byte instead of at `data_length`.

I checked this with a small host-side harness that mirrors the packet layout (length field + fixed payload array + a canary byte placed right after it): with the old code, setting `data_length == sizeof(payload)` reliably zeroes the canary; with the fix it stays untouched and the string is still correctly terminated for both the boundary case and normal shorter lengths.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved safety when processing ADB open requests by tightening receive-packet payload length validation to prevent potential out-of-bounds memory access.
  * Refined data length checking to eliminate an edge-case boundary condition specifically for `A_OPEN` requests, reducing the effect of malformed incoming messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->