### PR TITLE
fix(usbd): correct SetInterface endpoint handling for alternate settings

### DIFF
--- a/core/usbd_core.c
+++ b/core/usbd_core.c
@@ -540,11 +540,10 @@ static bool usbd_set_interface(uint8_t busid, uint8_t iface, uint8_t alt_setting
                 if (cur_iface == iface) {
                     ep_desc = (struct usb_endpoint_descriptor *)p;
 
-                    if (alt_setting == 0) {
-                        ret = usbd_reset_endpoint(busid, ep_desc);
-                    } else if (cur_alt_setting == alt_setting) {
+                    if (cur_alt_setting == alt_setting) {
                         ret = usbd_set_endpoint(busid, ep_desc);
                     } else {
+                        ret = usbd_reset_endpoint(busid, ep_desc);
                     }
                 }
 


### PR DESCRIPTION
The original code used 'alt_setting == 0' as the condition to close endpoints, which caused two problems:

1. When switching TO alt_setting=0: ALL endpoints (including the default ones) were closed but never re-opened, leaving the interface unusable.
2. When switching TO non-zero alt_setting: old endpoints were NOT closed, causing both old and new endpoints to remain active simultaneously.

Fix by comparing cur_alt_setting against the target alt_setting:
- cur_alt_setting == alt_setting: open/configure the endpoint
- cur_alt_setting != alt_setting: close/deactivate the endpoint

This ensures proper endpoint replacement when switching between alternate settings, as required by USB 2.0 specification section 9.1.1.5.