### PR TITLE
fix(idf): support legacy FatFS VFS registration API

### DIFF
--- a/platform/idf/usbh_fatfs.c
+++ b/platform/idf/usbh_fatfs.c
@@ -9,6 +9,7 @@
 #include "sdkconfig.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
+#include "esp_idf_version.h"
 #include "esp_log.h"
 #include "esp_check.h"
 #include "diskio_impl.h"
@@ -215,12 +216,16 @@ esp_err_t msc_host_vfs_register(struct usbh_msc *msc_class,
     strcpy(vfs->base_path, base_path);
     vfs->pdrv = pdrv;
 
+#if ESP_IDF_VERSION > ESP_IDF_VERSION_VAL(6, 0, 0)
     esp_vfs_fat_conf_t conf = {
         .base_path = base_path,
         .fat_drive = drive,
         .max_files = mount_config->max_files,
     };
     ret = esp_vfs_fat_register(&conf, &fs);
+#else
+    ret = esp_vfs_fat_register(base_path, drive, mount_config->max_files, &fs);
+#endif
     ESP_GOTO_ON_ERROR(ret, fail, TAG, "Failed to register filesystem, error=%s", esp_err_to_name(ret));
     vfs->fs = fs;
 


### PR DESCRIPTION
# Description

ESP-IDF `release/v5.5` is still widely used, so the `esp_vfs_fat_register()` call should remain compatible across different ESP-IDF versions.

The new `esp_vfs_fat_register()` API using `esp_vfs_fat_conf_t` is only available in ESP-IDF 6.0.1 and later. [ESP-IDF 6.0.0](https://github.com/espressif/esp-idf/blob/v6.0/components/fatfs/vfs/esp_vfs_fat.h#L451) and earlier, including `release/v5.5`, still use the legacy four-argument API.

This PR selects the appropriate API according to `ESP_IDF_VERSION`, preserving compatibility with both mainstream ESP-IDF 5.5 releases and newer versions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved FAT filesystem compatibility across different ESP-IDF versions.
  * Ensured filesystem registration uses the appropriate configuration method for each supported version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->