### PR TITLE
host: add optional hub re-enumerate and MSC ZeroCD modeswitch macros

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -332,6 +332,29 @@ if CHERRYUSB
             prompt "Enable usb msc driver"
             default n
 
+        config CONFIG_USBHOST_HUB_FORCE_REENUMERATE
+            bool
+            prompt "Force hub port re-enumeration API"
+            default n
+
+        config CONFIG_USBHOST_MSC_MODESWITCH_NO_CSW
+            bool
+            prompt "MSC modeswitch without waiting for CSW"
+            depends on CHERRYUSB_HOST_MSC
+            default n
+
+        config CONFIG_USBHOST_MSC_MODESWITCH_FORCE_REENUMERATE
+            bool
+            prompt "Re-enumerate after MSC modeswitch"
+            depends on CHERRYUSB_HOST_MSC && CONFIG_USBHOST_HUB_FORCE_REENUMERATE
+            default n
+
+        config CONFIG_USBHOST_MSC_MODESWITCH_DELAY_MS
+            int
+            prompt "Delay after MSC modeswitch (ms)"
+            depends on CHERRYUSB_HOST_MSC
+            default 0
+
         config CHERRYUSB_HOST_CDC_ECM
             bool
             prompt "Enable usb cdc ecm driver"

--- a/Kconfig.rtt
+++ b/Kconfig.rtt
@@ -356,6 +356,29 @@ if RT_USING_CHERRYUSB
             select RT_USING_DFS
             select RT_USING_DFS_ELMFAT
 
+        config CONFIG_USBHOST_HUB_FORCE_REENUMERATE
+            bool
+            prompt "Force hub port re-enumeration API"
+            default n
+
+        config CONFIG_USBHOST_MSC_MODESWITCH_NO_CSW
+            bool
+            prompt "MSC modeswitch without waiting for CSW"
+            depends on RT_CHERRYUSB_HOST_MSC
+            default n
+
+        config CONFIG_USBHOST_MSC_MODESWITCH_FORCE_REENUMERATE
+            bool
+            prompt "Re-enumerate after MSC modeswitch"
+            depends on RT_CHERRYUSB_HOST_MSC && CONFIG_USBHOST_HUB_FORCE_REENUMERATE
+            default n
+
+        config CONFIG_USBHOST_MSC_MODESWITCH_DELAY_MS
+            int
+            prompt "Delay after MSC modeswitch (ms)"
+            depends on RT_CHERRYUSB_HOST_MSC
+            default 0
+
         config RT_CHERRYUSB_HOST_CDC_ECM
             bool
             prompt "Enable usb cdc ecm driver"

--- a/Kconfig.rttpkg
+++ b/Kconfig.rttpkg
@@ -355,6 +355,29 @@ if PKG_USING_CHERRYUSB
             select RT_USING_DFS
             select RT_USING_DFS_ELMFAT
 
+        config CONFIG_USBHOST_HUB_FORCE_REENUMERATE
+            bool
+            prompt "Force hub port re-enumeration API"
+            default n
+
+        config CONFIG_USBHOST_MSC_MODESWITCH_NO_CSW
+            bool
+            prompt "MSC modeswitch without waiting for CSW"
+            depends on PKG_CHERRYUSB_HOST_MSC
+            default n
+
+        config CONFIG_USBHOST_MSC_MODESWITCH_FORCE_REENUMERATE
+            bool
+            prompt "Re-enumerate after MSC modeswitch"
+            depends on PKG_CHERRYUSB_HOST_MSC && CONFIG_USBHOST_HUB_FORCE_REENUMERATE
+            default n
+
+        config CONFIG_USBHOST_MSC_MODESWITCH_DELAY_MS
+            int
+            prompt "Delay after MSC modeswitch (ms)"
+            depends on PKG_CHERRYUSB_HOST_MSC
+            default 0
+
         config PKG_CHERRYUSB_HOST_CDC_ECM
             bool
             prompt "Enable usb cdc ecm driver"

--- a/cherryusb_config_template.h
+++ b/cherryusb_config_template.h
@@ -197,6 +197,26 @@
 #define CONFIG_USBHOST_MSC_TIMEOUT 5000
 #endif
 
+/* Request a hub port to walk debounce/reset/enumeration without a PHY pulse.
+ * Needed when a device reconnect is too short for the host controller to latch.
+ */
+// #define CONFIG_USBHOST_HUB_FORCE_REENUMERATE
+
+/* MSC usb_modeswitch: send CBW only. Some ZeroCD devices reboot and never
+ * return a CSW. Default remains the standard CBW + CSW transfer.
+ */
+// #define CONFIG_USBHOST_MSC_MODESWITCH_NO_CSW
+
+/* Optional delay after a successful modeswitch, then continue or re-enumerate. */
+#ifndef CONFIG_USBHOST_MSC_MODESWITCH_DELAY_MS
+#define CONFIG_USBHOST_MSC_MODESWITCH_DELAY_MS 0
+#endif
+
+/* After modeswitch, force the parent hub port to re-enumerate and do not
+ * register the temporary MSC device. Requires CONFIG_USBHOST_HUB_FORCE_REENUMERATE.
+ */
+// #define CONFIG_USBHOST_MSC_MODESWITCH_FORCE_REENUMERATE
+
 /* This parameter affects usb performance, and depends on (TCP_WND)tcp eceive windows size,
  * you can change to 2K ~ 16K and must be larger than TCP RX windows size in order to avoid being overflow.
  */

--- a/class/hub/usbh_hub.c
+++ b/class/hub/usbh_hub.c
@@ -481,6 +481,9 @@ static void usbh_hub_events(struct usbh_hub *hub)
     struct usbh_hubport *child;
     struct hub_port_status port_status;
     uint16_t portchange_index;
+#ifdef CONFIG_USBHOST_HUB_FORCE_REENUMERATE
+    uint16_t force_reenumerate;
+#endif
     uint16_t portstatus;
     uint16_t portchange;
     uint16_t mask;
@@ -497,7 +500,15 @@ static void usbh_hub_events(struct usbh_hub *hub)
 
     flags = usb_osal_enter_critical_section();
     memcpy(&portchange_index, hub->int_buffer, 2);
+#ifdef CONFIG_USBHOST_HUB_FORCE_REENUMERATE
+    force_reenumerate = hub->force_reenumerate;
+    hub->force_reenumerate = 0;
+#endif
     usb_osal_leave_critical_section(flags);
+
+#ifdef CONFIG_USBHOST_HUB_FORCE_REENUMERATE
+    portchange_index |= force_reenumerate;
+#endif
 
     for (uint8_t port = 0; port < hub->nports; port++) {
         USB_LOG_DBG("Port change:0x%02x\r\n", portchange_index);
@@ -518,6 +529,13 @@ static void usbh_hub_events(struct usbh_hub *hub)
         portstatus = port_status.wPortStatus;
         portchange = port_status.wPortChange;
 
+#ifdef CONFIG_USBHOST_HUB_FORCE_REENUMERATE
+        if (force_reenumerate & (1U << (port + 1))) {
+            USB_LOG_INFO("Force hub-port %u re-enumeration\r\n", port + 1);
+            portchange |= HUB_PORT_STATUS_C_CONNECTION;
+        }
+#endif
+
         USB_LOG_DBG("port %u, status:0x%03x, change:0x%02x\r\n", port + 1, portstatus, portchange);
 
         /* First, clear all change bits */
@@ -537,6 +555,11 @@ static void usbh_hub_events(struct usbh_hub *hub)
         }
 
         portchange = port_status.wPortChange;
+#ifdef CONFIG_USBHOST_HUB_FORCE_REENUMERATE
+        if (force_reenumerate & (1U << (port + 1))) {
+            portchange |= HUB_PORT_STATUS_C_CONNECTION;
+        }
+#endif
 
         /* Second, if port changes, debounces first */
         if (portchange & HUB_PORT_STATUS_C_CONNECTION) {
@@ -713,6 +736,25 @@ void usbh_hub_thread_wakeup(struct usbh_hub *hub)
 {
     usb_osal_mq_send(hub->bus->hub_mq, (uintptr_t)hub);
 }
+
+#ifdef CONFIG_USBHOST_HUB_FORCE_REENUMERATE
+int usbh_hub_force_reenumerate(struct usbh_hub *hub, uint8_t port)
+{
+    size_t flags;
+
+    if ((hub == NULL) || !hub->connected ||
+        (port == 0U) || (port > hub->nports) || (port > 15U)) {
+        return -USB_ERR_INVAL;
+    }
+
+    flags = usb_osal_enter_critical_section();
+    hub->force_reenumerate |= (uint16_t)(1U << port);
+    usb_osal_leave_critical_section(flags);
+
+    usbh_hub_thread_wakeup(hub);
+    return 0;
+}
+#endif
 
 int usbh_hub_initialize(struct usbh_bus *bus)
 {

--- a/class/hub/usbh_hub.h
+++ b/class/hub/usbh_hub.h
@@ -19,6 +19,11 @@ int usbh_hub_clear_feature(struct usbh_hub *hub, uint8_t port, uint8_t feature);
 
 void usbh_hub_thread_wakeup(struct usbh_hub *hub);
 
+#ifdef CONFIG_USBHOST_HUB_FORCE_REENUMERATE
+/* Force one port through the normal debounce/reset/enumeration path. */
+int usbh_hub_force_reenumerate(struct usbh_hub *hub, uint8_t port);
+#endif
+
 int usbh_hub_initialize(struct usbh_bus *bus);
 int usbh_hub_deinitialize(struct usbh_bus *bus);
 

--- a/class/msc/usbh_msc.c
+++ b/class/msc/usbh_msc.c
@@ -17,6 +17,15 @@
 #define CONFIG_USBHOST_MSC_READY_CHECK_TIMES 10
 #endif
 
+#ifndef CONFIG_USBHOST_MSC_MODESWITCH_DELAY_MS
+#define CONFIG_USBHOST_MSC_MODESWITCH_DELAY_MS 0
+#endif
+
+#if defined(CONFIG_USBHOST_MSC_MODESWITCH_FORCE_REENUMERATE) && \
+    !defined(CONFIG_USBHOST_HUB_FORCE_REENUMERATE)
+#error CONFIG_USBHOST_MSC_MODESWITCH_FORCE_REENUMERATE requires CONFIG_USBHOST_HUB_FORCE_REENUMERATE
+#endif
+
 USB_NOCACHE_RAM_SECTION USB_MEM_ALIGNX uint8_t g_msc_cbw_csw[CONFIG_USBHOST_MAX_MSC_CLASS][USB_ALIGN_UP(64, CONFIG_USB_ALIGN_SIZE)];
 USB_NOCACHE_RAM_SECTION USB_MEM_ALIGNX uint8_t g_msc_buf[CONFIG_USBHOST_MAX_MSC_CLASS][USB_ALIGN_UP(64, CONFIG_USB_ALIGN_SIZE)];
 
@@ -256,7 +265,7 @@ static inline int usbh_msc_scsi_readcapacity10(struct usbh_msc *msc_class)
     return usbh_bulk_cbw_csw_xfer(msc_class, cbw, (struct CSW *)g_msc_cbw_csw[msc_class->sdchar - 'a'], g_msc_buf[msc_class->sdchar - 'a'], CONFIG_USBHOST_MSC_TIMEOUT);
 }
 
-static inline void usbh_msc_modeswitch(struct usbh_msc *msc_class, const uint8_t *message)
+static inline int usbh_msc_modeswitch(struct usbh_msc *msc_class, const uint8_t *message)
 {
     struct CBW *cbw;
 
@@ -265,7 +274,28 @@ static inline void usbh_msc_modeswitch(struct usbh_msc *msc_class, const uint8_t
 
     memcpy(g_msc_cbw_csw[msc_class->sdchar - 'a'], message, 31);
 
-    usbh_bulk_cbw_csw_xfer(msc_class, cbw, (struct CSW *)g_msc_cbw_csw[msc_class->sdchar - 'a'], NULL, CONFIG_USBHOST_MSC_TIMEOUT);
+    usbh_msc_cbw_dump(cbw);
+#ifdef CONFIG_USBHOST_MSC_MODESWITCH_NO_CSW
+    {
+        int nbytes;
+
+        /* Some ZeroCD devices accept the CBW and reboot without a CSW. */
+        nbytes = usbh_msc_bulk_out_transfer(msc_class, (uint8_t *)cbw,
+                                            USB_SIZEOF_MSC_CBW,
+                                            CONFIG_USBHOST_MSC_TIMEOUT);
+        if (nbytes < 0) {
+            USB_LOG_ERR("usb_modeswitch CBW send failed: %d\r\n", nbytes);
+            return nbytes;
+        }
+
+        USB_LOG_INFO("usb_modeswitch CBW sent: %d bytes\r\n", nbytes);
+        return (nbytes == USB_SIZEOF_MSC_CBW) ? 0 : -USB_ERR_INVAL;
+    }
+#else
+    return usbh_bulk_cbw_csw_xfer(msc_class, cbw,
+                                  (struct CSW *)g_msc_cbw_csw[msc_class->sdchar - 'a'],
+                                  NULL, CONFIG_USBHOST_MSC_TIMEOUT);
+#endif
 }
 
 static int usbh_msc_connect(struct usbh_hubport *hport, uint8_t intf)
@@ -315,7 +345,27 @@ static int usbh_msc_connect(struct usbh_hubport *hport, uint8_t intf)
                 if ((hport->device_desc.idVendor == config->vid) &&
                     (hport->device_desc.idProduct == config->pid)) {
                     USB_LOG_INFO("%s usb_modeswitch enable\r\n", config->name);
-                    usbh_msc_modeswitch(msc_class, config->message_content);
+                    ret = usbh_msc_modeswitch(msc_class,
+                                              config->message_content);
+                    if (ret < 0) {
+                        USB_LOG_ERR("%s usb_modeswitch failed: %d\r\n",
+                                    config->name, ret);
+                        return ret;
+                    }
+
+#if CONFIG_USBHOST_MSC_MODESWITCH_DELAY_MS > 0
+                    usb_osal_msleep(CONFIG_USBHOST_MSC_MODESWITCH_DELAY_MS);
+#endif
+#ifdef CONFIG_USBHOST_MSC_MODESWITCH_FORCE_REENUMERATE
+                    ret = usbh_hub_force_reenumerate(hport->parent,
+                                                     hport->port);
+                    if (ret < 0) {
+                        USB_LOG_ERR("force re-enumeration failed: %d\r\n", ret);
+                        return ret;
+                    }
+                    USB_LOG_INFO("hub-port re-enumeration requested\r\n");
+                    return 0;
+#endif
                     return 0;
                 }
                 num++;

--- a/core/usbh_core.h
+++ b/core/usbh_core.h
@@ -174,6 +174,9 @@ struct usbh_hub {
     struct usb_endpoint_descriptor *intin;
     struct usbh_urb intin_urb;
     uint8_t *int_buffer;
+#ifdef CONFIG_USBHOST_HUB_FORCE_REENUMERATE
+    uint16_t force_reenumerate;
+#endif
     struct usb_osal_timer *int_timer;
 };
 

--- a/docs/en/api/api_config.rst
+++ b/docs/en/api/api_config.rst
@@ -160,3 +160,28 @@ CONFIG_USBHOST_MSC_TIMEOUT
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Timeout for MSC read/write transfers, default 5s
+
+CONFIG_USBHOST_HUB_FORCE_REENUMERATE
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Expose ``usbh_hub_force_reenumerate()`` so a class can restart the normal
+debounce/reset/enumeration path when a reconnect pulse is too short for
+the host controller to latch. Disabled by default.
+
+CONFIG_USBHOST_MSC_MODESWITCH_NO_CSW
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+MSC usb_modeswitch sends the CBW only and does not wait for a CSW.
+Some ZeroCD devices reboot after the CBW. Disabled by default (CBW+CSW).
+
+CONFIG_USBHOST_MSC_MODESWITCH_DELAY_MS
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Milliseconds to sleep after a successful MSC modeswitch. Default 0.
+
+CONFIG_USBHOST_MSC_MODESWITCH_FORCE_REENUMERATE
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+After MSC modeswitch, force the parent hub port to re-enumerate and do
+not register the temporary MSC device. Requires
+``CONFIG_USBHOST_HUB_FORCE_REENUMERATE``. Disabled by default.

--- a/docs/zh/api/api_config.rst
+++ b/docs/zh/api/api_config.rst
@@ -161,3 +161,26 @@ CONFIG_USBHOST_MSC_TIMEOUT
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 MSC 读写传输的超时时间，默认 5s
+
+CONFIG_USBHOST_HUB_FORCE_REENUMERATE
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+提供 ``usbh_hub_force_reenumerate()``。设备重连脉冲过短、主机控制器抓不到
+连接变化时，class 可以走原来的 debounce/reset/枚举路径。默认关闭。
+
+CONFIG_USBHOST_MSC_MODESWITCH_NO_CSW
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+MSC usb_modeswitch 只发 CBW，不等 CSW。部分 ZeroCD 设备在 CBW 后会重启。
+默认关闭（仍走 CBW+CSW）。
+
+CONFIG_USBHOST_MSC_MODESWITCH_DELAY_MS
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+MSC modeswitch 成功后的延时，单位毫秒，默认 0。
+
+CONFIG_USBHOST_MSC_MODESWITCH_FORCE_REENUMERATE
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+MSC modeswitch 后强制父 hub 端口重新枚举，并且不注册临时 MSC 设备。
+需要 ``CONFIG_USBHOST_HUB_FORCE_REENUMERATE``。默认关闭。


### PR DESCRIPTION
## Summary
- Add `CONFIG_USBHOST_HUB_FORCE_REENUMERATE` so a class can restart the normal hub debounce/reset/enumeration path when a reconnect pulse is too short for the host controller to latch.
- Add MSC modeswitch options (default off): send CBW without waiting for CSW, optional delay, and force parent-port re-enumeration after a successful switch.
- Defaults keep the existing CBW+CSW behavior. Validated with an AIC8800D80 ZeroCD stick (`1111:1111` -> `a69c:8d80`).

## Test plan
- [ ] Host MSC without the new macros: existing disks still enumerate (CBW+CSW).
- [ ] Enable the macros and register a ZeroCD modeswitch: device leaves `1111:1111` and re-enumerates.
- [ ] Confirm Kconfig / `cherryusb_config_template.h` / api_config docs match the macros.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added USB host support for forcing hub-port re-enumeration.
  - Added MSC modeswitch options for devices that do not return a completion response.
  - Added configurable delay after successful MSC modeswitching.
  - Added an option to re-enumerate the parent hub port after modeswitching.

- **Documentation**
  - Documented the new USB host and MSC configuration options in English and Chinese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->