### PR TITLE
update(port/ch32): optimize ch32 usbhs controller port

### DIFF
--- a/port/ch32/usbhs/usb_usbhs_dc.c
+++ b/port/ch32/usbhs/usb_usbhs_dc.c
@@ -11,28 +11,23 @@
 #define CONFIG_USBDEV_EP_NUM 8
 #endif
 
-#define USBHSD ((USBHSD_TypeDef *)g_usbdev_bus[busid].reg_base)
-
+#define USBHSD           ((USBHSD_TypeDef *)g_usbdev_bus[busid].reg_base)
 #define ENDP_MAX_LEN(ep) *((__IO uint32_t *)&(USBHSD->UEP0_MAX_LEN) + (ep))
-#define ENDP_TX_LEN(ep)  *((__IO uint16_t *)&(USBHSD->UEP0_TX_LEN) + (ep)*2)
-#define ENDP_RX_LEN(ep)  *((__IO uint16_t *)&(USBHSD->UEP0_RX_LEN) + (ep)*2)
+#define ENDP_TX_LEN(ep)  *((__IO uint16_t *)&(USBHSD->UEP0_TX_LEN) + (ep) * 2)
+#define ENDP_RX_LEN(ep)  *((__IO uint16_t *)&(USBHSD->UEP0_RX_LEN) + (ep) * 2)
 #define ENDP_RX_SIZE(ep) *((__IO uint16_t *)&(USBHSD->UEP1_RX_SIZE) + (ep - 1) * 2)
-#define ENDP_TX_CTRL(ep) *((__IO uint8_t *)&(USBHSD->UEP0_TX_CTRL) + (ep)*4)
-#define ENDP_RX_CTRL(ep) *((__IO uint8_t *)&(USBHSD->UEP0_RX_CTRL) + (ep)*4)
+#define ENDP_TX_CTRL(ep) *((__IO uint8_t *)&(USBHSD->UEP0_TX_CTRL) + (ep) * 4)
+#define ENDP_RX_CTRL(ep) *((__IO uint8_t *)&(USBHSD->UEP0_RX_CTRL) + (ep) * 4)
 #define ENDP_TX_DMA(ep)  *((__IO uint32_t *)&(USBHSD->UEP1_TX_DMA) + (ep - 1))
 #define ENDP_RX_DMA(ep)  *((__IO uint32_t *)&(USBHSD->UEP1_RX_DMA) + (ep - 1))
 
 struct ch32_usbhs_ep_state {
     uint16_t ep_mps;
-    uint8_t eptype;
-    uint8_t ep_enable;
-    uint8_t *xfer_buf;
     uint32_t xfer_len;
     uint32_t actual_xfer_len;
 };
 
 struct ch32_usbhs_udc {
-    uint8_t address;
     struct ch32_usbhs_ep_state ep_in[CONFIG_USBDEV_EP_NUM];
     struct ch32_usbhs_ep_state ep_out[CONFIG_USBDEV_EP_NUM];
     struct usb_setup_packet setup;
@@ -53,8 +48,13 @@ int usb_dc_init(uint8_t busid)
     USBHSD->CONTROL = USBHS_UD_RST_LINK | USBHS_UD_PHY_SUSPENDM;
     USBHSD->INT_EN = USBHS_UDIE_BUS_RST | USBHS_UDIE_SUSPEND | USBHS_UDIE_BUS_SLEEP | USBHS_UDIE_LPM_ACT |
                      USBHS_UDIE_TRANSFER | USBHS_UDIE_LINK_RDY;
-    USBHSD->UEP_TX_EN = USBHS_UEP0_T_EN;
-    USBHSD->UEP_RX_EN = USBHS_UEP0_R_EN;
+
+    USBHSD->UEP_TX_EN = 0;
+    USBHSD->UEP_RX_EN = 0;
+    USBHSD->UEP_TX_TOG_AUTO = 0;
+    USBHSD->UEP_RX_TOG_AUTO = 0;
+    USBHSD->UEP_TX_ISO = 0;
+    USBHSD->UEP_RX_ISO = 0;
     USBHSD->BASE_MODE = USBHS_UD_SPEED_HIGH;
     USBHSD->CONTROL = USBHS_UD_DEV_EN | USBHS_UD_DMA_EN | USBHS_UD_LPM_EN | USBHS_UD_PHY_SUSPENDM;
     return 0;
@@ -69,7 +69,6 @@ int usb_dc_deinit(uint8_t busid)
 
 int usbd_set_address(uint8_t busid, const uint8_t addr)
 {
-    g_ch32_usbhs_udc[busid].address = addr;
     USBHSD->DEV_AD = addr;
     return 0;
 }
@@ -95,7 +94,7 @@ int usbd_ep_open(uint8_t busid, const struct usb_endpoint_descriptor *ep)
 {
     uint8_t epid = USB_EP_GET_IDX(ep->bEndpointAddress);
 
-    if (epid > (CONFIG_USBDEV_EP_NUM - 1)) {
+    if (epid >= CONFIG_USBDEV_EP_NUM) {
         USB_LOG_ERR("Ep addr %02x overflow\r\n", ep->bEndpointAddress);
         return -1;
     }
@@ -105,18 +104,20 @@ int usbd_ep_open(uint8_t busid, const struct usb_endpoint_descriptor *ep)
     ENDP_MAX_LEN(epid) = ep_mps;
 
     if (USB_EP_DIR_IS_IN(ep->bEndpointAddress)) {
-        g_ch32_usbhs_udc[busid].ep_in[epid].ep_enable = true;
         g_ch32_usbhs_udc[busid].ep_in[epid].ep_mps = ep_mps;
-        g_ch32_usbhs_udc[busid].ep_in[epid].eptype = USB_GET_ENDPOINT_TYPE(ep->bmAttributes);
         USBHSD->UEP_TX_EN |= bit;
         USBHSD->UEP_TX_TOG_AUTO |= bit;
+        USBHSD->UEP_TX_ISO = USB_GET_ENDPOINT_TYPE(ep->bmAttributes) == USB_ENDPOINT_TYPE_ISOCHRONOUS ?
+                                 USBHSD->UEP_TX_ISO | bit :
+                                 USBHSD->UEP_TX_ISO & ~bit;
         ENDP_TX_CTRL(epid) = USBHS_UEP_T_RES_NAK;
     } else {
-        g_ch32_usbhs_udc[busid].ep_out[epid].ep_enable = true;
         g_ch32_usbhs_udc[busid].ep_out[epid].ep_mps = ep_mps;
-        g_ch32_usbhs_udc[busid].ep_out[epid].eptype = USB_GET_ENDPOINT_TYPE(ep->bmAttributes);
         USBHSD->UEP_RX_EN |= bit;
         USBHSD->UEP_RX_TOG_AUTO |= bit;
+        USBHSD->UEP_RX_ISO = USB_GET_ENDPOINT_TYPE(ep->bmAttributes) == USB_ENDPOINT_TYPE_ISOCHRONOUS ?
+                                 USBHSD->UEP_RX_ISO | bit :
+                                 USBHSD->UEP_RX_ISO & ~bit;
         ENDP_RX_CTRL(epid) = USBHS_UEP_R_RES_NAK;
     }
     return 0;
@@ -127,11 +128,9 @@ int usbd_ep_close(uint8_t busid, const uint8_t ep)
     uint8_t epid = USB_EP_GET_IDX(ep);
     uint32_t bit = 1 << epid;
     if (USB_EP_DIR_IS_IN(ep)) {
-        g_ch32_usbhs_udc[busid].ep_in[epid].ep_enable = false;
         USBHSD->UEP_TX_EN &= ~bit;
         USBHSD->UEP_TX_TOG_AUTO &= ~bit;
     } else {
-        g_ch32_usbhs_udc[busid].ep_out[epid].ep_enable = false;
         USBHSD->UEP_RX_EN &= ~bit;
         USBHSD->UEP_RX_TOG_AUTO &= ~bit;
     }
@@ -177,14 +176,16 @@ int usbd_ep_start_write(uint8_t busid, const uint8_t ep, const uint8_t *data, ui
     if (!data && data_len) {
         return -1;
     }
-    if (!g_ch32_usbhs_udc[busid].ep_in[ep_idx].ep_enable) {
+    if (!(USBHSD->UEP_TX_EN & (1 << ep_idx))) {
         return -2;
     }
     if ((uint32_t)data & 0x03) {
         return -3;
     }
+    if ((ENDP_TX_CTRL(ep_idx) & USBHS_UEP_T_RES_MASK) != USBHS_UEP_T_RES_NAK) {
+        return -4;
+    }
 
-    g_ch32_usbhs_udc[busid].ep_in[ep_idx].xfer_buf = (uint8_t *)data;
     g_ch32_usbhs_udc[busid].ep_in[ep_idx].xfer_len = data_len;
     g_ch32_usbhs_udc[busid].ep_in[ep_idx].actual_xfer_len = 0;
 
@@ -206,14 +207,13 @@ int usbd_ep_start_read(uint8_t busid, const uint8_t ep, uint8_t *data, uint32_t 
     if (!data && data_len) {
         return -1;
     }
-    if (!g_ch32_usbhs_udc[busid].ep_out[ep_idx].ep_enable) {
+    if (!(USBHSD->UEP_RX_EN & (1 << ep_idx))) {
         return -2;
     }
     if ((uint32_t)data & 0x03) {
         return -3;
     }
 
-    g_ch32_usbhs_udc[busid].ep_out[ep_idx].xfer_buf = (uint8_t *)data;
     g_ch32_usbhs_udc[busid].ep_out[ep_idx].xfer_len = data_len;
     g_ch32_usbhs_udc[busid].ep_out[ep_idx].actual_xfer_len = 0;
 
@@ -223,6 +223,7 @@ int usbd_ep_start_read(uint8_t busid, const uint8_t ep, uint8_t *data, uint32_t 
         ENDP_RX_DMA(ep_idx) = (uint32_t)data;
     }
 
+    ENDP_RX_SIZE(ep_idx) = MIN(data_len, g_ch32_usbhs_udc[busid].ep_out[ep_idx].ep_mps);
     ENDP_RX_CTRL(ep_idx) = (ENDP_RX_CTRL(ep_idx) & ~USBHS_UEP_R_RES_MASK) | USBHS_UEP_R_RES_ACK;
     return 0;
 }
@@ -236,11 +237,11 @@ static inline void handle_ep0_in(uint8_t busid)
         if (g_ch32_usbhs_udc[busid].ep_in[0].xfer_len > g_ch32_usbhs_udc[busid].ep_in[0].ep_mps) {
             g_ch32_usbhs_udc[busid].ep_in[0].xfer_len -= g_ch32_usbhs_udc[busid].ep_in[0].ep_mps;
             g_ch32_usbhs_udc[busid].ep_in[0].actual_xfer_len += g_ch32_usbhs_udc[busid].ep_in[0].ep_mps;
-            usbd_event_ep_in_complete_handler(0, 0x80 | 0, g_ch32_usbhs_udc[busid].ep_in[0].actual_xfer_len);
+            usbd_event_ep_in_complete_handler(0, 0x80, g_ch32_usbhs_udc[busid].ep_in[0].actual_xfer_len);
         } else {
             g_ch32_usbhs_udc[busid].ep_in[0].actual_xfer_len += g_ch32_usbhs_udc[busid].ep_in[0].xfer_len;
             g_ch32_usbhs_udc[busid].ep_in[0].xfer_len = 0;
-            usbd_event_ep_in_complete_handler(0, 0x80 | 0, g_ch32_usbhs_udc[busid].ep_in[0].actual_xfer_len);
+            usbd_event_ep_in_complete_handler(0, 0x80, g_ch32_usbhs_udc[busid].ep_in[0].actual_xfer_len);
         }
     } else {
         USBHSD->UEP0_DMA = (uint32_t)&g_ch32_usbhs_udc[busid].setup;
@@ -254,22 +255,17 @@ static inline void handle_non_ep0_in(uint8_t busid, uint8_t epid)
     ENDP_TX_CTRL(epid) = (ENDP_TX_CTRL(epid) & ~USBHS_UEP_T_RES_MASK) | USBHS_UEP_T_RES_NAK;
 
     if (g_ch32_usbhs_udc[busid].ep_in[epid].xfer_len > g_ch32_usbhs_udc[busid].ep_in[epid].ep_mps) {
-        g_ch32_usbhs_udc[busid].ep_in[epid].xfer_buf += g_ch32_usbhs_udc[busid].ep_in[epid].ep_mps;
         g_ch32_usbhs_udc[busid].ep_in[epid].xfer_len -= g_ch32_usbhs_udc[busid].ep_in[epid].ep_mps;
         g_ch32_usbhs_udc[busid].ep_in[epid].actual_xfer_len += g_ch32_usbhs_udc[busid].ep_in[epid].ep_mps;
 
         uint32_t write_count = MIN(g_ch32_usbhs_udc[busid].ep_in[epid].xfer_len, g_ch32_usbhs_udc[busid].ep_in[epid].ep_mps);
         ENDP_TX_LEN(epid) = write_count;
-        ENDP_TX_DMA(epid) = (uint32_t)g_ch32_usbhs_udc[busid].ep_in[epid].xfer_buf;
-
-        if (g_ch32_usbhs_udc[busid].ep_in[epid].eptype != USB_ENDPOINT_TYPE_ISOCHRONOUS) {
-            ENDP_TX_CTRL(epid) = (ENDP_TX_CTRL(epid) & ~USBHS_UEP_T_RES_MASK) | USBHS_UEP_T_RES_ACK;
-        } else {
-        }
+        ENDP_TX_DMA(epid) += g_ch32_usbhs_udc[busid].ep_in[epid].ep_mps;
+        ENDP_TX_CTRL(epid) = (ENDP_TX_CTRL(epid) & ~USBHS_UEP_T_RES_MASK) | USBHS_UEP_T_RES_ACK;
     } else {
         g_ch32_usbhs_udc[busid].ep_in[epid].actual_xfer_len += g_ch32_usbhs_udc[busid].ep_in[epid].xfer_len;
         g_ch32_usbhs_udc[busid].ep_in[epid].xfer_len = 0;
-        usbd_event_ep_in_complete_handler(0, epid | 0x80, g_ch32_usbhs_udc[busid].ep_in[epid].actual_xfer_len);
+        usbd_event_ep_in_complete_handler(0, 0x80 | epid, g_ch32_usbhs_udc[busid].ep_in[epid].actual_xfer_len);
     }
 }
 
@@ -290,18 +286,15 @@ static inline void handle_ep0_out(uint8_t busid)
 static inline void handle_non_ep0_out(uint8_t busid, uint8_t epid)
 {
     uint32_t read_count = ENDP_RX_LEN(epid);
-    g_ch32_usbhs_udc[busid].ep_out[epid].xfer_buf += read_count;
     g_ch32_usbhs_udc[busid].ep_out[epid].actual_xfer_len += read_count;
     g_ch32_usbhs_udc[busid].ep_out[epid].xfer_len -= read_count;
 
     if ((read_count < g_ch32_usbhs_udc[busid].ep_out[epid].ep_mps) || (g_ch32_usbhs_udc[busid].ep_out[epid].xfer_len == 0)) {
-        usbd_event_ep_out_complete_handler(0, ((epid)&0x7f), g_ch32_usbhs_udc[busid].ep_out[epid].actual_xfer_len);
+        usbd_event_ep_out_complete_handler(0, epid, g_ch32_usbhs_udc[busid].ep_out[epid].actual_xfer_len);
     } else {
-        ENDP_RX_DMA(epid) = (uint32_t)g_ch32_usbhs_udc[busid].ep_out[epid].xfer_buf;
-        if (g_ch32_usbhs_udc[busid].ep_out[epid].eptype != USB_ENDPOINT_TYPE_ISOCHRONOUS) {
-            ENDP_RX_CTRL(epid) = (ENDP_RX_CTRL(epid) & ~USBHS_UEP_R_RES_MASK) | USBHS_UEP_R_RES_ACK;
-        } else {
-        }
+        ENDP_RX_DMA(epid) += g_ch32_usbhs_udc[busid].ep_out[epid].ep_mps;
+        ENDP_RX_SIZE(epid) = MIN(g_ch32_usbhs_udc[busid].ep_out[epid].xfer_len, g_ch32_usbhs_udc[busid].ep_out[epid].ep_mps);
+        ENDP_RX_CTRL(epid) = (ENDP_RX_CTRL(epid) & ~USBHS_UEP_R_RES_MASK) | USBHS_UEP_R_RES_ACK;
     }
 }
 
@@ -318,7 +311,10 @@ void USBD_IRQHandler(uint8_t busid)
         if (endp == 0x00 && !dir && (ENDP_RX_CTRL(0) & USBHS_UEP_R_SETUP_IS)) {
             ENDP_TX_CTRL(0) = (ENDP_TX_CTRL(0) & ~USBHS_UEP_T_TOG_MASK) | USBHS_UEP_T_TOG_DATA1;
             ENDP_RX_CTRL(0) = (ENDP_RX_CTRL(0) & ~USBHS_UEP_R_TOG_MASK) | USBHS_UEP_R_TOG_DATA1;
-
+            if (!(g_ch32_usbhs_udc[busid].setup.bmRequestType & 0x80)) {
+                ENDP_TX_LEN(0) = 0;
+                ENDP_TX_CTRL(0) = (ENDP_TX_CTRL(0) & ~USBHS_UEP_T_RES_MASK) | USBHS_UEP_T_RES_ACK;
+            }
             usbd_event_ep0_setup_complete_handler(0, (uint8_t *)&g_ch32_usbhs_udc[busid].setup);
             ENDP_RX_CTRL(0) = (ENDP_RX_CTRL(0) & ~USBHS_UEP_R_DONE);
         }
@@ -329,7 +325,6 @@ void USBD_IRQHandler(uint8_t busid)
             } else {
                 handle_non_ep0_in(busid, endp);
             }
-
             ENDP_TX_CTRL(endp) = (ENDP_TX_CTRL(endp) & ~USBHS_UEP_T_DONE);
         }
         // OUT transfer
@@ -339,25 +334,24 @@ void USBD_IRQHandler(uint8_t busid)
             } else {
                 handle_non_ep0_out(busid, endp);
             }
+            ENDP_RX_LEN(endp) = 0;
             ENDP_RX_CTRL(endp) = (ENDP_RX_CTRL(endp) & ~USBHS_UEP_R_DONE);
         }
         // OUT transfer toggle mismatch
         else {
-            ENDP_RX_CTRL(endp) = (ENDP_RX_CTRL(endp) & ~(USBHS_UEP_R_DONE | USBHS_UEP_R_RES_MASK)) |
-                                 USBHS_UEP_R_RES_ACK;
+            ENDP_RX_CTRL(endp) = (ENDP_RX_CTRL(endp) & ~(USBHS_UEP_R_DONE | USBHS_UEP_R_RES_MASK)) | USBHS_UEP_R_RES_ACK;
         }
     } else if (flag & USBHS_UDIF_BUS_RST) {
         USBHSD->DEV_AD = 0;
-        usbd_event_reset_handler(0);
         USBHSD->UEP0_DMA = (uint32_t)&g_ch32_usbhs_udc[busid].setup;
         USBHSD->UEP0_TX_CTRL = USBHS_UEP_T_RES_NAK;
         USBHSD->UEP0_RX_CTRL = USBHS_UEP_R_RES_ACK;
+        usbd_event_reset_handler(0);
         USBHSD->INT_FG = USBHS_UDIF_BUS_RST;
     } else if (flag & USBHS_UDIF_SUSPEND) {
         if (USBHSD->MIS_ST & USBHS_UDMS_SUSPEND) {
             usbd_event_suspend_handler(busid);
         }
-
         USBHSD->INT_FG = USBHS_UDIF_SUSPEND;
     } else {
         USBHSD->INT_FG = flag;


### PR DESCRIPTION
Optimize ch32 usbhs controller port.
Test cdc_acm_template 500MB file loopback passed.
Test audio_v1_mic_speaker_multichan_template synchronous transmission passed.
Test hid_remote_wakeup_template remote wakeup passed.
<img width="686" height="578" alt="image" src="https://github.com/user-attachments/assets/50656f27-3c03-4097-b1eb-c7d1e5c31ce8" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved USB high-speed endpoint initialization and state handling.
  * Improved transfer validation and DMA address progression.
  * Improved OUT transfer packet-size programming.
  * Added handling for zero-length control-IN responses.
  * Improved interrupt behavior for receive-length clearing and toggle mismatches.
  * Improved USB reset handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->